### PR TITLE
MVP: add work command compatibility for repo workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,25 @@ let artifact = execution_service
 
 ### 7. Repo Workbench MVP Quickstart
 
+The Repo Workbench can be accessed through two command surfaces:
+
+**Product-facing path (preferred):**
+
+```bash
+cargo run -- work create \
+  --repo . \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review
+
+cargo run -- work run <work_id>
+cargo run -- work artifacts <work_id>
+cargo run -- work approve <artifact_id>
+cargo run -- work memory show <work_id>
+cargo run -- work continue <work_id>
+```
+
+**Legacy path (same implementation):**
+
 ```bash
 cargo run -- repo create \
   --repo . \
@@ -218,7 +237,7 @@ cargo run -- repo memory show <work_id>
 cargo run -- repo continue <work_id>
 ```
 
-The Repo Workbench is a local-first, file-backed MVP that scans a repository for risky code patterns, generates a risk report and suggested patch plan, requires explicit approval, and persists memory for continuation.
+Both surfaces share the same implementation. The Repo Workbench is a local-first, file-backed MVP that scans a repository for risky code patterns, generates a risk report and suggested patch plan, requires explicit approval, and persists memory for continuation.
 
 See [docs/guides/repo-workbench-mvp.md](docs/guides/repo-workbench-mvp.md) for the full guide.
 

--- a/docs/guides/repo-workbench-mvp.md
+++ b/docs/guides/repo-workbench-mvp.md
@@ -6,6 +6,21 @@ The MVP is intentionally small, local-first, and file-backed. It does not mutate
 
 ## Command Surface
 
+The Repo Workbench MVP supports two command surfaces:
+
+### Product-facing path (preferred)
+
+```bash
+prometheos work create --repo . --goal "Find risky code and suggest safe improvements" --mode review
+prometheos work run <work_id>
+prometheos work artifacts <work_id>
+prometheos work approve <artifact_id>
+prometheos work memory show <work_id>
+prometheos work continue <work_id>
+```
+
+### Legacy/direct path
+
 ```bash
 prometheos repo create --repo . --goal "Find risky code and suggest safe improvements" --mode review
 prometheos repo run <work_id>
@@ -22,7 +37,29 @@ prometheos repo continue <work_id>
 prometheos repo-workbench status <work_id>
 ```
 
+Both surfaces call the same implementation. The `work` path is the product-facing interface; `repo` remains available for backward compatibility.
+
 ## Golden Path
+
+```bash
+# Product-facing path
+cargo run -- work create \
+  --repo . \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review
+
+cargo run -- work run <work_id>
+
+cargo run -- work artifacts <work_id>
+
+cargo run -- work approve <artifact_id>
+
+cargo run -- work memory show <work_id>
+
+cargo run -- work continue <work_id>
+```
+
+### Legacy path (same implementation)
 
 ```bash
 cargo run -- repo create \

--- a/src/cli/commands/repo_workbench.rs
+++ b/src/cli/commands/repo_workbench.rs
@@ -1,19 +1,12 @@
 //! Local repo workbench MVP command.
 //!
-//! This module intentionally keeps the first Repo Workbench path small and file-backed.
-//! It does not mutate the target repository. Suggested patches are staged as artifacts and
-//! require explicit approval before any future writer is allowed to apply them.
+//! Thin CLI wrapper around `prometheos_lite::repo_workbench` service functions.
 
-use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
-use serde::{Deserialize, Serialize};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-use uuid::Uuid;
-use walkdir::{DirEntry, WalkDir};
+use std::path::PathBuf;
+
+use prometheos_lite::repo_workbench;
 
 #[derive(Debug, Parser)]
 pub struct RepoWorkbenchCommand {
@@ -82,69 +75,6 @@ enum MemorySubcommand {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct WorkbenchContext {
-    id: String,
-    title: String,
-    goal: String,
-    mode: String,
-    repo_path: PathBuf,
-    status: String,
-    phase: String,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-    repo_summary: RepoSummary,
-    artifacts: Vec<ArtifactRef>,
-    decisions: Vec<DecisionRecord>,
-    next_action: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct RepoSummary {
-    project_type: String,
-    files_scanned: usize,
-    candidate_files: Vec<FileSummary>,
-    ignored_dirs: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct FileSummary {
-    path: String,
-    bytes: u64,
-    lines: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ArtifactRef {
-    id: String,
-    kind: String,
-    title: String,
-    path: PathBuf,
-    status: String,
-    requires_approval: bool,
-    created_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct DecisionRecord {
-    id: String,
-    artifact_id: String,
-    decision: String,
-    approved: bool,
-    created_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone)]
-struct RiskFinding {
-    id: String,
-    file: String,
-    line: usize,
-    risk: &'static str,
-    category: &'static str,
-    summary: String,
-    recommendation: String,
-}
-
 impl RepoWorkbenchCommand {
     pub async fn execute(self) -> Result<()> {
         match self.command {
@@ -154,32 +84,8 @@ impl RepoWorkbenchCommand {
                 mode,
                 title,
             } => {
-                let repo_path = normalize_repo_path(&repo)?;
-                let summary = scan_repo(&repo_path)?;
-                let id = Uuid::new_v4().to_string();
-                let now = Utc::now();
-                let title = title.unwrap_or_else(|| title_from_goal(&goal));
-                let context = WorkbenchContext {
-                    id: id.clone(),
-                    title,
-                    goal,
-                    mode,
-                    repo_path: repo_path.clone(),
-                    status: "draft".to_string(),
-                    phase: "intake".to_string(),
-                    created_at: now,
-                    updated_at: now,
-                    repo_summary: summary,
-                    artifacts: Vec::new(),
-                    decisions: Vec::new(),
-                    next_action: Some(
-                        "Run `prometheos repo run <work_id>` to perform read-only risk review."
-                            .to_string(),
-                    ),
-                };
-
-                save_context(&context)?;
-                write_memory(&context, &[])?;
+                let context =
+                    repo_workbench::create_repo_workbench_context(&repo, &goal, &mode, title)?;
 
                 println!("Created Repo Workbench WorkContext");
                 println!("  ID: {}", context.id);
@@ -194,52 +100,8 @@ impl RepoWorkbenchCommand {
                 println!("  Next: prometheos repo run {}", context.id);
             }
             RepoWorkbenchSubcommand::Run { id } => {
-                let mut context = load_context_from_current_repo(&id)?;
-                context.status = "in_progress".to_string();
-                context.phase = "review".to_string();
-                context.repo_summary = scan_repo(&context.repo_path)?;
-
-                let findings = analyze_risks(&context.repo_path, &context.repo_summary)?;
-                let report = render_risk_report(&context, &findings);
-                let patch = render_patch_suggestions(&context, &findings);
-
-                let report_artifact = write_artifact(
-                    &context,
-                    "risk-report",
-                    "Risk Review Report",
-                    "ready",
-                    false,
-                    &report,
-                )?;
-                let patch_artifact = write_artifact(
-                    &context,
-                    "suggested-patch",
-                    "Suggested Patch Plan",
-                    "awaiting_approval",
-                    true,
-                    &patch,
-                )?;
-
-                upsert_artifact(&mut context, report_artifact);
-                upsert_artifact(&mut context, patch_artifact);
-                context.status = "awaiting_approval".to_string();
-                context.phase = "approval".to_string();
-                context.next_action = context
-                    .artifacts
-                    .iter()
-                    .find(|artifact| {
-                        artifact.requires_approval && artifact.status == "awaiting_approval"
-                    })
-                    .map(|artifact| {
-                        format!(
-                            "Review `{}` and approve with `prometheos repo approve {}`.",
-                            artifact.title, artifact.id
-                        )
-                    });
-                context.updated_at = Utc::now();
-
-                save_context(&context)?;
-                write_memory(&context, &findings)?;
+                let mut context = repo_workbench::load_context(&id)?;
+                repo_workbench::run_repo_workbench_context(&mut context)?;
 
                 let risk_report = context.artifacts.iter().find(|a| a.kind == "risk-report");
                 let patch_artifact = context
@@ -254,7 +116,7 @@ impl RepoWorkbenchCommand {
                     "  Files considered: {}",
                     context.repo_summary.candidate_files.len()
                 );
-                println!("  Findings: {}", findings.len());
+                println!("  Findings: {}", context.artifacts.len());
                 if let Some(report) = risk_report {
                     println!("  Risk report: {}", report.path.display());
                 }
@@ -266,11 +128,11 @@ impl RepoWorkbenchCommand {
                 }
             }
             RepoWorkbenchSubcommand::Status { id } => {
-                let context = load_context_from_current_repo(&id)?;
-                print_status(&context);
+                let context = repo_workbench::load_context(&id)?;
+                repo_workbench::print_status(&context);
             }
             RepoWorkbenchSubcommand::Artifacts { id } => {
-                let context = load_context_from_current_repo(&id)?;
+                let context = repo_workbench::load_context(&id)?;
                 println!("Artifacts for {}:", context.id);
                 if context.artifacts.is_empty() {
                     println!(
@@ -278,7 +140,7 @@ impl RepoWorkbenchCommand {
                         context.id
                     );
                 }
-                for artifact in &context.artifacts {
+                for artifact in repo_workbench::get_artifacts(&context) {
                     println!("  {}", artifact.id);
                     println!("    Title: {}", artifact.title);
                     println!("    Kind: {}", artifact.kind);
@@ -291,42 +153,13 @@ impl RepoWorkbenchCommand {
                 artifact_id,
                 work_id,
             } => {
-                let mut context = if let Some(work_id) = work_id {
-                    load_context_from_current_repo(&work_id)?
+                let mut context = if let Some(ref work_id) = work_id {
+                    repo_workbench::load_context(work_id)?
                 } else {
-                    find_context_by_artifact(&artifact_id)?
+                    repo_workbench::find_context_by_artifact(&artifact_id)?
                 };
 
-                let artifact = context
-                    .artifacts
-                    .iter_mut()
-                    .find(|artifact| artifact.id == artifact_id)
-                    .with_context(|| format!("Artifact `{}` not found", artifact_id))?;
-
-                if !artifact.requires_approval {
-                    println!(
-                        "Artifact `{}` does not require approval; recording acknowledgement anyway.",
-                        artifact.id
-                    );
-                }
-
-                artifact.status = "approved".to_string();
-                context.decisions.push(DecisionRecord {
-                    id: Uuid::new_v4().to_string(),
-                    artifact_id: artifact_id.clone(),
-                    decision: "approved_for_future_application".to_string(),
-                    approved: true,
-                    created_at: Utc::now(),
-                });
-                context.status = "approved".to_string();
-                context.phase = "ready_to_apply".to_string();
-                context.next_action = Some(
-                    "Approval recorded. MVP does not apply patches automatically; future writer must consume the approved artifact explicitly."
-                        .to_string(),
-                );
-                context.updated_at = Utc::now();
-                save_context(&context)?;
-                write_memory(&context, &[])?;
+                repo_workbench::approve_artifact(&mut context, &artifact_id)?;
 
                 println!("Approval recorded");
                 println!("  WorkContext: {}", context.id);
@@ -335,12 +168,12 @@ impl RepoWorkbenchCommand {
                 println!("  Next: prometheos repo continue {}", context.id);
             }
             RepoWorkbenchSubcommand::Continue { id } => {
-                let context = load_context_from_current_repo(&id)?;
+                let context = repo_workbench::load_context(&id)?;
                 println!("Continuing Repo Workbench WorkContext");
-                print_status(&context);
+                repo_workbench::print_status(&context);
                 println!();
                 println!("Memory:");
-                println!("{}", load_memory(&context)?);
+                println!("{}", repo_workbench::load_memory(&context)?);
                 if let Some(next) = &context.next_action {
                     println!();
                     println!("Recommended next action: {}", next);
@@ -348,8 +181,8 @@ impl RepoWorkbenchCommand {
             }
             RepoWorkbenchSubcommand::Memory { command } => match command {
                 MemorySubcommand::Show { id } => {
-                    let context = load_context_from_current_repo(&id)?;
-                    println!("{}", load_memory(&context)?);
+                    let context = repo_workbench::load_context(&id)?;
+                    println!("{}", repo_workbench::load_memory(&context)?);
                 }
             },
         }
@@ -358,478 +191,13 @@ impl RepoWorkbenchCommand {
     }
 }
 
-fn normalize_repo_path(repo: &Path) -> Result<PathBuf> {
-    let path = if repo.is_absolute() {
-        repo.to_path_buf()
-    } else {
-        std::env::current_dir()?.join(repo)
-    };
-    let path = path
-        .canonicalize()
-        .with_context(|| format!("Repository path does not exist: {}", path.display()))?;
-    if !path.is_dir() {
-        anyhow::bail!("Repository path is not a directory: {}", path.display());
-    }
-    Ok(path)
-}
-
-fn title_from_goal(goal: &str) -> String {
-    let trimmed = goal.trim();
-    if trimmed.len() <= 48 {
-        return trimmed.to_string();
-    }
-    format!("{}...", &trimmed[..48])
-}
-
-fn store_root(repo_path: &Path) -> PathBuf {
-    repo_path.join(".prometheos-lite").join("workbench")
-}
-
-fn contexts_dir(repo_path: &Path) -> PathBuf {
-    store_root(repo_path).join("contexts")
-}
-
-fn artifacts_dir(repo_path: &Path, work_id: &str) -> PathBuf {
-    store_root(repo_path).join("artifacts").join(work_id)
-}
-
-fn memory_dir(repo_path: &Path) -> PathBuf {
-    store_root(repo_path).join("memory")
-}
-
-fn context_path(context: &WorkbenchContext) -> PathBuf {
-    contexts_dir(&context.repo_path).join(format!("{}.json", context.id))
-}
-
-fn load_context_from_current_repo(id: &str) -> Result<WorkbenchContext> {
-    let repo_path = normalize_repo_path(Path::new("."))?;
-    let path = contexts_dir(&repo_path).join(format!("{}.json", id));
-    let json = fs::read_to_string(&path)
-        .with_context(|| format!("WorkContext `{}` not found at {}", id, path.display()))?;
-    let context = serde_json::from_str(&json)?;
-    Ok(context)
-}
-
-fn find_context_by_artifact(artifact_id: &str) -> Result<WorkbenchContext> {
-    let repo_path = normalize_repo_path(Path::new("."))?;
-    let dir = contexts_dir(&repo_path);
-    for entry in fs::read_dir(&dir)
-        .with_context(|| format!("Context directory not found: {}", dir.display()))?
-    {
-        let entry = entry?;
-        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
-            continue;
-        }
-        let json = fs::read_to_string(entry.path())?;
-        let context: WorkbenchContext = serde_json::from_str(&json)?;
-        if context
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.id == artifact_id)
-        {
-            return Ok(context);
-        }
-    }
-    anyhow::bail!(
-        "Artifact `{}` not found in current repo workbench store",
-        artifact_id
-    )
-}
-
-fn save_context(context: &WorkbenchContext) -> Result<()> {
-    fs::create_dir_all(contexts_dir(&context.repo_path))?;
-    let json = serde_json::to_string_pretty(context)?;
-    fs::write(context_path(context), json)?;
-    Ok(())
-}
-
-fn scan_repo(repo_path: &Path) -> Result<RepoSummary> {
-    let mut files = Vec::new();
-    let mut ignored_dirs = vec![
-        ".git".to_string(),
-        "target".to_string(),
-        "node_modules".to_string(),
-        "dist".to_string(),
-        "build".to_string(),
-        ".prometheos-lite".to_string(),
-    ];
-
-    for entry in WalkDir::new(repo_path)
-        .into_iter()
-        .filter_entry(|entry| !is_ignored(entry))
-        .filter_map(|entry| entry.ok())
-    {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if !is_candidate_file(path) {
-            continue;
-        }
-        let metadata = fs::metadata(path)?;
-        if metadata.len() > 200_000 {
-            continue;
-        }
-        let content = fs::read_to_string(path).unwrap_or_default();
-        let relative = path
-            .strip_prefix(repo_path)
-            .unwrap_or(path)
-            .to_string_lossy()
-            .replace('\\', "/");
-        files.push(FileSummary {
-            path: relative,
-            bytes: metadata.len(),
-            lines: content.lines().count(),
-        });
-        if files.len() >= 80 {
-            break;
-        }
-    }
-
-    ignored_dirs.sort();
-    ignored_dirs.dedup();
-
-    Ok(RepoSummary {
-        project_type: detect_project_type(repo_path),
-        files_scanned: files.len(),
-        candidate_files: files,
-        ignored_dirs,
-    })
-}
-
-fn is_ignored(entry: &DirEntry) -> bool {
-    let name = entry.file_name().to_string_lossy();
-    matches!(
-        name.as_ref(),
-        ".git" | "target" | "node_modules" | "dist" | "build" | ".prometheos-lite"
-    )
-}
-
-fn is_candidate_file(path: &Path) -> bool {
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default();
-    if matches!(
-        file_name,
-        "Cargo.toml" | "package.json" | "pyproject.toml" | "go.mod" | "README.md"
-    ) {
-        return true;
-    }
-    matches!(
-        path.extension().and_then(|ext| ext.to_str()),
-        Some(
-            "rs" | "ts"
-                | "tsx"
-                | "js"
-                | "jsx"
-                | "py"
-                | "go"
-                | "java"
-                | "cpp"
-                | "c"
-                | "h"
-                | "toml"
-                | "yaml"
-                | "yml"
-        )
-    )
-}
-
-fn detect_project_type(repo_path: &Path) -> String {
-    if repo_path.join("Cargo.toml").exists() {
-        "rust".to_string()
-    } else if repo_path.join("package.json").exists() {
-        "node".to_string()
-    } else if repo_path.join("pyproject.toml").exists()
-        || repo_path.join("requirements.txt").exists()
-    {
-        "python".to_string()
-    } else if repo_path.join("go.mod").exists() {
-        "go".to_string()
-    } else {
-        "unknown".to_string()
-    }
-}
-
-fn analyze_risks(repo_path: &Path, summary: &RepoSummary) -> Result<Vec<RiskFinding>> {
-    let mut findings = Vec::new();
-
-    for file in &summary.candidate_files {
-        let path = repo_path.join(&file.path);
-        let Ok(content) = fs::read_to_string(&path) else {
-            continue;
-        };
-        for (idx, line) in content.lines().enumerate() {
-            let line_number = idx + 1;
-            let lower = line.to_lowercase();
-
-            let finding = if line.contains(".unwrap()") || line.contains("unwrap(") {
-                Some((
-                    "Medium",
-                    "panic-risk",
-                    "Potential panic from unwrap".to_string(),
-                    "Replace unwrap with structured error handling or a safe fallback.".to_string(),
-                ))
-            } else if line.contains(".expect(") || line.contains("panic!(") {
-                Some((
-                    "Medium",
-                    "panic-risk",
-                    "Explicit panic path in application code".to_string(),
-                    "Return a typed error or convert the panic into a controlled failure path."
-                        .to_string(),
-                ))
-            } else if lower.contains("todo!") || lower.contains("fixme") || lower.contains("todo:")
-            {
-                Some((
-                    "Low",
-                    "unfinished-work",
-                    "Unfinished implementation marker".to_string(),
-                    "Convert the marker into a tracked task or complete the implementation before release.".to_string(),
-                ))
-            } else if looks_like_hardcoded_secret(&lower) {
-                Some((
-                    "High",
-                    "secret-risk",
-                    "Possible hardcoded secret or credential".to_string(),
-                    "Move the value into environment-backed configuration or a secret manager."
-                        .to_string(),
-                ))
-            } else if lower.contains("eval(") {
-                Some((
-                    "High",
-                    "code-execution-risk",
-                    "Dynamic eval call detected".to_string(),
-                    "Avoid eval or strictly constrain and validate input before execution."
-                        .to_string(),
-                ))
-            } else if lower.contains("shell=true") {
-                Some((
-                    "High",
-                    "command-injection-risk",
-                    "Shell execution with shell=True detected".to_string(),
-                    "Use argument arrays and avoid shell interpolation for subprocess execution."
-                        .to_string(),
-                ))
-            } else if lower.contains("innerhtml") {
-                Some((
-                    "Medium",
-                    "xss-risk",
-                    "Direct innerHTML usage detected".to_string(),
-                    "Prefer safe DOM APIs or sanitize trusted markup before insertion.".to_string(),
-                ))
-            } else {
-                None
-            };
-
-            if let Some((risk, category, summary, recommendation)) = finding {
-                findings.push(RiskFinding {
-                    id: format!("F-{:03}", findings.len() + 1),
-                    file: file.path.clone(),
-                    line: line_number,
-                    risk,
-                    category,
-                    summary,
-                    recommendation,
-                });
-            }
-        }
-    }
-
-    Ok(findings)
-}
-
-fn looks_like_hardcoded_secret(lower: &str) -> bool {
-    let mentions_secret = ["api_key", "apikey", "secret", "password", "token"]
-        .iter()
-        .any(|needle| lower.contains(needle));
-    mentions_secret && lower.contains('=') && !lower.contains("env") && !lower.contains("example")
-}
-
-fn render_risk_report(context: &WorkbenchContext, findings: &[RiskFinding]) -> String {
-    let mut out = String::new();
-    out.push_str("# Risk Review\n\n");
-    out.push_str("## Summary\n\n");
-    out.push_str(&format!(
-        "PrometheOS Lite reviewed `{}` and found {} risk finding(s) across {} candidate file(s).\n\n",
-        context.repo_path.display(),
-        findings.len(),
-        context.repo_summary.candidate_files.len()
-    ));
-    out.push_str("## WorkContext\n\n");
-    out.push_str(&format!("- ID: `{}`\n", context.id));
-    out.push_str(&format!("- Goal: {}\n", context.goal));
-    out.push_str(&format!("- Mode: {}\n", context.mode));
-    out.push_str(&format!(
-        "- Project type: {}\n\n",
-        context.repo_summary.project_type
-    ));
-
-    if findings.is_empty() {
-        out.push_str("## Findings\n\nNo obvious risky patterns were found by the MVP heuristic scanner. This does not mean the repo is safe; it means the boring little scanner did not catch anything obvious.\n");
-        return out;
-    }
-
-    out.push_str("## Findings\n\n");
-    for finding in findings {
-        out.push_str(&format!("### {}. {}\n\n", finding.id, finding.summary));
-        out.push_str(&format!("- File: `{}`\n", finding.file));
-        out.push_str(&format!("- Line: {}\n", finding.line));
-        out.push_str(&format!("- Risk: {}\n", finding.risk));
-        out.push_str(&format!("- Category: {}\n", finding.category));
-        out.push_str(&format!("- Suggested fix: {}\n\n", finding.recommendation));
-    }
-
-    out
-}
-
-fn render_patch_suggestions(context: &WorkbenchContext, findings: &[RiskFinding]) -> String {
-    let mut out = String::new();
-    out.push_str("# Suggested Patch Plan\n\n");
-    out.push_str("> Safety note: this MVP artifact is a staged suggestion only. No repository files were modified.\n\n");
-    out.push_str(&format!("WorkContext: `{}`\n\n", context.id));
-
-    if findings.is_empty() {
-        out.push_str("No patch suggestions were generated because the MVP risk scanner found no obvious risky patterns.\n");
-        return out;
-    }
-
-    out.push_str("## Recommended Changes\n\n");
-    for finding in findings.iter().take(20) {
-        out.push_str(&format!(
-            "### {}: `{}` line {}\n\n",
-            finding.id, finding.file, finding.line
-        ));
-        out.push_str(&format!(
-            "Risk: {} / {}\n\n",
-            finding.risk, finding.category
-        ));
-        out.push_str(&format!("Suggested change: {}\n\n", finding.recommendation));
-    }
-
-    out.push_str("## Approval\n\n");
-    out.push_str("Approve this artifact when the suggestions are acceptable. The current MVP records approval only; an explicit future writer must apply changes.\n");
-    out
-}
-
-fn write_artifact(
-    context: &WorkbenchContext,
-    kind: &str,
-    title: &str,
-    status: &str,
-    requires_approval: bool,
-    content: &str,
-) -> Result<ArtifactRef> {
-    let id = Uuid::new_v4().to_string();
-    let dir = artifacts_dir(&context.repo_path, &context.id);
-    fs::create_dir_all(&dir)?;
-    let filename = format!("{}-{}.md", kind, &id[..8]);
-    let path = dir.join(filename);
-    fs::write(&path, content)?;
-    Ok(ArtifactRef {
-        id,
-        kind: kind.to_string(),
-        title: title.to_string(),
-        path,
-        status: status.to_string(),
-        requires_approval,
-        created_at: Utc::now(),
-    })
-}
-
-fn upsert_artifact(context: &mut WorkbenchContext, artifact: ArtifactRef) {
-    context
-        .artifacts
-        .retain(|existing| existing.kind != artifact.kind);
-    context.artifacts.push(artifact);
-}
-
-fn write_memory(context: &WorkbenchContext, findings: &[RiskFinding]) -> Result<()> {
-    fs::create_dir_all(memory_dir(&context.repo_path))?;
-    let mut out = String::new();
-    out.push_str("# Repo Workbench Memory\n\n");
-    out.push_str(&format!("- WorkContext: `{}`\n", context.id));
-    out.push_str(&format!("- Title: {}\n", context.title));
-    out.push_str(&format!("- Goal: {}\n", context.goal));
-    out.push_str(&format!("- Repo: `{}`\n", context.repo_path.display()));
-    out.push_str(&format!("- Status: {}\n", context.status));
-    out.push_str(&format!("- Phase: {}\n", context.phase));
-    out.push_str(&format!(
-        "- Project type: {}\n",
-        context.repo_summary.project_type
-    ));
-    out.push_str(&format!(
-        "- Candidate files: {}\n",
-        context.repo_summary.candidate_files.len()
-    ));
-    out.push_str(&format!("- Artifacts: {}\n", context.artifacts.len()));
-    out.push_str(&format!("- Decisions: {}\n", context.decisions.len()));
-    if let Some(next) = &context.next_action {
-        out.push_str(&format!("- Next action: {}\n", next));
-    }
-
-    if !findings.is_empty() {
-        out.push_str("\n## Latest Findings\n\n");
-        for finding in findings.iter().take(20) {
-            out.push_str(&format!(
-                "- {} `{}`:{} [{}] {}\n",
-                finding.id, finding.file, finding.line, finding.risk, finding.summary
-            ));
-        }
-    }
-
-    if !context.artifacts.is_empty() {
-        out.push_str("\n## Artifacts\n\n");
-        for artifact in &context.artifacts {
-            out.push_str(&format!(
-                "- `{}` {} ({}, status: {}, approval: {}) at `{}`\n",
-                artifact.id,
-                artifact.title,
-                artifact.kind,
-                artifact.status,
-                artifact.requires_approval,
-                artifact.path.display()
-            ));
-        }
-    }
-
-    fs::write(
-        memory_dir(&context.repo_path).join(format!("{}.md", context.id)),
-        out,
-    )?;
-    Ok(())
-}
-
-fn load_memory(context: &WorkbenchContext) -> Result<String> {
-    let path = memory_dir(&context.repo_path).join(format!("{}.md", context.id));
-    fs::read_to_string(&path).with_context(|| format!("Memory not found at {}", path.display()))
-}
-
-fn print_status(context: &WorkbenchContext) {
-    println!("Repo Workbench WorkContext");
-    println!("  ID: {}", context.id);
-    println!("  Title: {}", context.title);
-    println!("  Goal: {}", context.goal);
-    println!("  Repo: {}", context.repo_path.display());
-    println!("  Status: {}", context.status);
-    println!("  Phase: {}", context.phase);
-    println!("  Project type: {}", context.repo_summary.project_type);
-    println!(
-        "  Candidate files: {}",
-        context.repo_summary.candidate_files.len()
-    );
-    println!("  Artifacts: {}", context.artifacts.len());
-    println!("  Decisions: {}", context.decisions.len());
-    if let Some(next) = &context.next_action {
-        println!("  Next: {}", next);
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
+    use std::path::Path;
     use tempfile::TempDir;
+
+    use prometheos_lite::repo_workbench;
 
     fn temp_repo() -> TempDir {
         tempfile::tempdir().expect("tempdir")
@@ -843,717 +211,52 @@ mod tests {
         fs::write(&path, content).unwrap();
     }
 
-    fn make_context(repo_path: &Path) -> WorkbenchContext {
-        WorkbenchContext {
-            id: "test-id".to_string(),
-            title: "Test".to_string(),
-            goal: "Find issues".to_string(),
-            mode: "review".to_string(),
-            repo_path: repo_path.to_path_buf(),
-            status: "draft".to_string(),
-            phase: "intake".to_string(),
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            repo_summary: RepoSummary::default(),
-            artifacts: Vec::new(),
-            decisions: Vec::new(),
-            next_action: None,
-        }
-    }
-
-    // ── is_ignored ────────────────────────────────────────────────────────
-
     #[test]
-    fn test_is_ignored_dot_git() {
-        let _entry = walkdir::WalkDir::new(".")
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
-        // Check by name: we just test the match logic directly
-        assert!(is_ignored_inner(".git"));
-        assert!(is_ignored_inner("target"));
-        assert!(is_ignored_inner("node_modules"));
-        assert!(is_ignored_inner("dist"));
-        assert!(is_ignored_inner("build"));
-        assert!(is_ignored_inner(".prometheos-lite"));
-        assert!(!is_ignored_inner("src"));
-        assert!(!is_ignored_inner("Cargo.toml"));
-    }
+    fn test_work_create_repo_delegates() {
+        let dir = temp_repo();
+        write_file(dir.path(), "Cargo.toml", "[package]\nname = \"test\"\n");
+        write_file(dir.path(), "src/main.rs", "fn main() {}");
 
-    /// Helper that tests the name-based match without needing a DirEntry
-    fn is_ignored_inner(name: &str) -> bool {
-        matches!(
-            name,
-            ".git" | "target" | "node_modules" | "dist" | "build" | ".prometheos-lite"
+        let context = repo_workbench::create_repo_workbench_context(
+            dir.path(),
+            "Find issues",
+            "review",
+            None,
         )
+        .expect("create should succeed");
+
+        assert_eq!(context.status, "draft");
+        assert_eq!(context.phase, "intake");
+        assert_eq!(context.repo_path, dir.path().canonicalize().unwrap());
+        assert!(context.id.len() > 10);
     }
 
-    // ── scan_repo ─────────────────────────────────────────────────────────
-
     #[test]
-    fn test_scan_repo_ignores_ignored_dirs() {
+    fn test_work_create_repo_with_custom_title() {
         let dir = temp_repo();
-        let root = dir.path();
+        write_file(dir.path(), "Cargo.toml", "[package]\nname = \"test\"\n");
 
-        write_file(root, "Cargo.toml", "[package]\nname = \"test\"\n");
-        write_file(root, ".git/HEAD", "ref: refs/heads/main\n");
-        write_file(root, "target/debug/test.o", "");
-        write_file(root, "node_modules/pkg/index.js", "// dep");
-        write_file(root, ".prometheos-lite/workbench/contexts/test.json", "{}");
-
-        let summary = scan_repo(root).unwrap();
-        let paths: Vec<&str> = summary
-            .candidate_files
-            .iter()
-            .map(|f| f.path.as_str())
-            .collect();
-        assert!(
-            paths.contains(&"Cargo.toml"),
-            "Cargo.toml should be scanned"
-        );
-        assert!(
-            !paths.iter().any(|p| p.contains(".git")),
-            ".git should be ignored"
-        );
-        assert!(
-            !paths.iter().any(|p| p.contains("target/")),
-            "target should be ignored"
-        );
-        assert!(
-            !paths.iter().any(|p| p.contains("node_modules/")),
-            "node_modules should be ignored"
-        );
-        assert!(
-            !paths.iter().any(|p| p.contains(".prometheos-lite")),
-            ".prometheos-lite should be ignored"
-        );
-    }
-
-    // ── detect_project_type ───────────────────────────────────────────────
-
-    #[test]
-    fn test_detect_project_type_rust() {
-        let dir = temp_repo();
-        write_file(dir.path(), "Cargo.toml", "[package]\n");
-        assert_eq!(detect_project_type(dir.path()), "rust");
-    }
-
-    #[test]
-    fn test_detect_project_type_node() {
-        let dir = temp_repo();
-        write_file(dir.path(), "package.json", "{}");
-        assert_eq!(detect_project_type(dir.path()), "node");
-    }
-
-    #[test]
-    fn test_detect_project_type_python_pyproject() {
-        let dir = temp_repo();
-        write_file(dir.path(), "pyproject.toml", "[project]\n");
-        assert_eq!(detect_project_type(dir.path()), "python");
-    }
-
-    #[test]
-    fn test_detect_project_type_python_requirements() {
-        let dir = temp_repo();
-        write_file(dir.path(), "requirements.txt", "requests\n");
-        assert_eq!(detect_project_type(dir.path()), "python");
-    }
-
-    #[test]
-    fn test_detect_project_type_go() {
-        let dir = temp_repo();
-        write_file(dir.path(), "go.mod", "module test\n");
-        assert_eq!(detect_project_type(dir.path()), "go");
-    }
-
-    #[test]
-    fn test_detect_project_type_unknown() {
-        let dir = temp_repo();
-        assert_eq!(detect_project_type(dir.path()), "unknown");
-    }
-
-    // ── is_candidate_file ─────────────────────────────────────────────────
-
-    #[test]
-    fn test_is_candidate_file_extensions() {
-        assert!(is_candidate_file_inner("main.rs"));
-        assert!(is_candidate_file_inner("lib.ts"));
-        assert!(is_candidate_file_inner("app.tsx"));
-        assert!(is_candidate_file_inner("index.js"));
-        assert!(is_candidate_file_inner("app.jsx"));
-        assert!(is_candidate_file_inner("script.py"));
-        assert!(is_candidate_file_inner("main.go"));
-        assert!(is_candidate_file_inner("App.java"));
-        assert!(is_candidate_file_inner("lib.cpp"));
-        assert!(is_candidate_file_inner("lib.c"));
-        assert!(is_candidate_file_inner("lib.h"));
-        assert!(is_candidate_file_inner("conf.toml"));
-        assert!(is_candidate_file_inner("config.yaml"));
-        assert!(is_candidate_file_inner("config.yml"));
-        assert!(!is_candidate_file_inner("image.png"));
-        assert!(!is_candidate_file_inner("data.json"));
-        assert!(!is_candidate_file_inner("file.md"));
-    }
-
-    #[test]
-    fn test_is_candidate_file_special_names() {
-        assert!(is_candidate_file_inner("Cargo.toml"));
-        assert!(is_candidate_file_inner("package.json"));
-        assert!(is_candidate_file_inner("pyproject.toml"));
-        assert!(is_candidate_file_inner("go.mod"));
-        assert!(is_candidate_file_inner("README.md"));
-    }
-
-    fn is_candidate_file_inner(name: &str) -> bool {
-        let path = Path::new(name);
-        let file_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or_default();
-        if matches!(
-            file_name,
-            "Cargo.toml" | "package.json" | "pyproject.toml" | "go.mod" | "README.md"
-        ) {
-            return true;
-        }
-        matches!(
-            path.extension().and_then(|ext| ext.to_str()),
-            Some(
-                "rs" | "ts"
-                    | "tsx"
-                    | "js"
-                    | "jsx"
-                    | "py"
-                    | "go"
-                    | "java"
-                    | "cpp"
-                    | "c"
-                    | "h"
-                    | "toml"
-                    | "yaml"
-                    | "yml"
-            )
+        let context = repo_workbench::create_repo_workbench_context(
+            dir.path(),
+            "Find issues",
+            "review",
+            Some("Custom Title".to_string()),
         )
-    }
+        .expect("create should succeed");
 
-    // ── analyze_risks ─────────────────────────────────────────────────────
-
-    fn make_summary_with_file(repo_path: &Path, relative: &str) -> RepoSummary {
-        let metadata = fs::metadata(repo_path.join(relative)).unwrap();
-        RepoSummary {
-            project_type: "rust".to_string(),
-            files_scanned: 1,
-            candidate_files: vec![FileSummary {
-                path: relative.to_string(),
-                bytes: metadata.len(),
-                lines: fs::read_to_string(repo_path.join(relative))
-                    .unwrap()
-                    .lines()
-                    .count(),
-            }],
-            ignored_dirs: vec![],
-        }
+        assert_eq!(context.title, "Custom Title");
     }
 
     #[test]
-    fn test_analyze_risks_detects_unwrap() {
-        let dir = temp_repo();
-        write_file(
-            dir.path(),
-            "src/main.rs",
-            "fn main() { let x = data.unwrap(); }",
-        );
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.summary.contains("unwrap")),
-            "should detect unwrap"
-        );
+    fn test_context_exists_returns_false_for_bogus_id() {
+        assert!(!repo_workbench::repo_workbench_context_exists(
+            "nonexistent-id-12345"
+        ));
     }
 
     #[test]
-    fn test_analyze_risks_detects_expect() {
-        let dir = temp_repo();
-        write_file(
-            dir.path(),
-            "src/main.rs",
-            "fn main() { let x = data.expect(\"msg\"); }",
-        );
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.summary.contains("panic")),
-            "should detect expect"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_panic() {
-        let dir = temp_repo();
-        write_file(dir.path(), "src/main.rs", "fn main() { panic!(\"boom\"); }");
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.summary.contains("panic")),
-            "should detect panic"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_todo() {
-        let dir = temp_repo();
-        write_file(
-            dir.path(),
-            "src/main.rs",
-            "fn main() { // TODO: implement this }",
-        );
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.category == "unfinished-work"),
-            "should detect TODO"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_fixme() {
-        let dir = temp_repo();
-        write_file(
-            dir.path(),
-            "src/main.rs",
-            "fn main() { // FIXME: handle error }",
-        );
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.category == "unfinished-work"),
-            "should detect FIXME"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_hardcoded_secret() {
-        let dir = temp_repo();
-        write_file(
-            dir.path(),
-            "src/main.rs",
-            "fn main() { let api_key = \"sk-123\"; }",
-        );
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.category == "secret-risk"),
-            "should detect hardcoded secret"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_eval() {
-        let dir = temp_repo();
-        write_file(dir.path(), "src/main.rs", "fn main() { eval(user_input); }");
-        let summary = make_summary_with_file(dir.path(), "src/main.rs");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.category == "code-execution-risk"),
-            "should detect eval"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_shell_true() {
-        let dir = temp_repo();
-        write_file(dir.path(), "script.py", "subprocess.run(cmd, shell=True)");
-        let summary = make_summary_with_file(dir.path(), "script.py");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings
-                .iter()
-                .any(|f| f.category == "command-injection-risk"),
-            "should detect shell=True"
-        );
-    }
-
-    #[test]
-    fn test_analyze_risks_detects_innerhtml() {
-        let dir = temp_repo();
-        write_file(
-            dir.path(),
-            "app.js",
-            "document.getElementById('x').innerHTML = html;",
-        );
-        let summary = make_summary_with_file(dir.path(), "app.js");
-        let findings = analyze_risks(dir.path(), &summary).unwrap();
-        assert!(
-            findings.iter().any(|f| f.category == "xss-risk"),
-            "should detect innerHTML"
-        );
-    }
-
-    // ── render_risk_report ───────────────────────────────────────────────
-
-    #[test]
-    fn test_render_risk_report_creates_output() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let findings = vec![RiskFinding {
-            id: "F-001".to_string(),
-            file: "src/main.rs".to_string(),
-            line: 5,
-            risk: "Medium",
-            category: "panic-risk",
-            summary: "Potential panic from unwrap".to_string(),
-            recommendation: "Replace unwrap".to_string(),
-        }];
-        let report = render_risk_report(&context, &findings);
-        assert!(report.contains("# Risk Review"), "should have title");
-        assert!(report.contains("F-001"), "should contain finding ID");
-        assert!(report.contains("Potential panic"), "should contain summary");
-    }
-
-    #[test]
-    fn test_render_risk_report_empty() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let report = render_risk_report(&context, &[]);
-        assert!(
-            report.contains("No obvious risky patterns"),
-            "empty case message"
-        );
-    }
-
-    // ── render_patch_suggestions ──────────────────────────────────────────
-
-    #[test]
-    fn test_render_patch_suggestions_creates_output() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let findings = vec![RiskFinding {
-            id: "F-001".to_string(),
-            file: "src/main.rs".to_string(),
-            line: 5,
-            risk: "Medium",
-            category: "panic-risk",
-            summary: "Potential panic".to_string(),
-            recommendation: "Replace with error handling".to_string(),
-        }];
-        let patch = render_patch_suggestions(&context, &findings);
-        assert!(
-            patch.contains("# Suggested Patch Plan"),
-            "should have title"
-        );
-        assert!(patch.contains("F-001"), "should contain finding ID");
-        assert!(patch.contains("Approval"), "should mention approval");
-    }
-
-    #[test]
-    fn test_render_patch_suggestions_empty() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let patch = render_patch_suggestions(&context, &[]);
-        assert!(patch.contains("No patch suggestions"), "empty case message");
-    }
-
-    // ── write_artifact ────────────────────────────────────────────────────
-
-    #[test]
-    fn test_write_artifact_creates_file() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let artifact = write_artifact(
-            &context,
-            "risk-report",
-            "Test Report",
-            "ready",
-            false,
-            "# Report",
-        )
-        .unwrap();
-        assert!(artifact.path.exists(), "artifact file should exist on disk");
-        let content = fs::read_to_string(&artifact.path).unwrap();
-        assert_eq!(content.trim(), "# Report");
-        assert_eq!(artifact.kind, "risk-report");
-        assert_eq!(artifact.status, "ready");
-        assert!(!artifact.requires_approval);
-    }
-
-    #[test]
-    fn test_write_artifact_requires_approval() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let artifact = write_artifact(
-            &context,
-            "suggested-patch",
-            "Patch",
-            "awaiting_approval",
-            true,
-            "# Patch",
-        )
-        .unwrap();
-        assert!(artifact.requires_approval);
-        assert_eq!(artifact.status, "awaiting_approval");
-    }
-
-    // ── upsert_artifact ───────────────────────────────────────────────────
-
-    #[test]
-    fn test_upsert_artifact_replaces_by_kind() {
-        let mut context = make_context(Path::new("/tmp"));
-        let a1 = ArtifactRef {
-            id: "id-1".to_string(),
-            kind: "risk-report".to_string(),
-            title: "Old".to_string(),
-            path: PathBuf::from("/tmp/a.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        };
-        let a2 = ArtifactRef {
-            id: "id-2".to_string(),
-            kind: "risk-report".to_string(),
-            title: "New".to_string(),
-            path: PathBuf::from("/tmp/b.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        };
-        context.artifacts.push(a1);
-        upsert_artifact(&mut context, a2);
-        assert_eq!(
-            context.artifacts.len(),
-            1,
-            "old artifact should be replaced"
-        );
-        assert_eq!(
-            context.artifacts[0].id, "id-2",
-            "new artifact should be present"
-        );
-    }
-
-    #[test]
-    fn test_upsert_artifact_appends_different_kind() {
-        let mut context = make_context(Path::new("/tmp"));
-        let a1 = ArtifactRef {
-            id: "id-1".to_string(),
-            kind: "risk-report".to_string(),
-            title: "Report".to_string(),
-            path: PathBuf::from("/tmp/a.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        };
-        let a2 = ArtifactRef {
-            id: "id-2".to_string(),
-            kind: "suggested-patch".to_string(),
-            title: "Patch".to_string(),
-            path: PathBuf::from("/tmp/b.md"),
-            status: "awaiting_approval".to_string(),
-            requires_approval: true,
-            created_at: Utc::now(),
-        };
-        context.artifacts.push(a1);
-        upsert_artifact(&mut context, a2);
-        assert_eq!(
-            context.artifacts.len(),
-            2,
-            "different kinds should both be present"
-        );
-    }
-
-    // ── write_memory ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_write_memory_includes_required_fields() {
-        let dir = temp_repo();
-        let mut context = make_context(dir.path());
-        context.id = "mem-test-id".to_string();
-        context.goal = "Find issues".to_string();
-        context.status = "awaiting_approval".to_string();
-        context.next_action = Some("Approve the patch".to_string());
-        context.artifacts.push(ArtifactRef {
-            id: "art-1".to_string(),
-            kind: "risk-report".to_string(),
-            title: "Report".to_string(),
-            path: PathBuf::from("report.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        });
-
-        write_memory(&context, &[]).unwrap();
-
-        let memory_path = memory_dir(dir.path()).join("mem-test-id.md");
-        assert!(memory_path.exists(), "memory file should exist");
-        let content = fs::read_to_string(&memory_path).unwrap();
-        assert!(
-            content.contains("mem-test-id"),
-            "should contain work context ID"
-        );
-        assert!(content.contains("Find issues"), "should contain goal");
-        assert!(
-            content.contains(&dir.path().to_string_lossy().to_string()),
-            "should contain repo path"
-        );
-        assert!(
-            content.contains("awaiting_approval"),
-            "should contain status"
-        );
-        assert!(content.contains("Report"), "should contain artifact info");
-        assert!(
-            content.contains("Approve the patch"),
-            "should contain next action"
-        );
-    }
-
-    #[test]
-    fn test_write_memory_with_findings() {
-        let dir = temp_repo();
-        let context = make_context(dir.path());
-        let findings = vec![RiskFinding {
-            id: "F-001".to_string(),
-            file: "src/main.rs".to_string(),
-            line: 5,
-            risk: "Medium",
-            category: "panic-risk",
-            summary: "Potential panic".to_string(),
-            recommendation: "Fix it".to_string(),
-        }];
-        write_memory(&context, &findings).unwrap();
-        let memory_path = memory_dir(dir.path()).join("test-id.md");
-        let content = fs::read_to_string(&memory_path).unwrap();
-        assert!(content.contains("F-001"), "should contain finding ID");
-        assert!(
-            content.contains("Potential panic"),
-            "should contain finding summary"
-        );
-    }
-
-    // ── approve flow ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_approve_updates_status() {
-        let dir = temp_repo();
-        let mut context = make_context(dir.path());
-        let artifact_id = "approve-test-id".to_string();
-        context.artifacts.push(ArtifactRef {
-            id: artifact_id.clone(),
-            kind: "suggested-patch".to_string(),
-            title: "Patch".to_string(),
-            path: PathBuf::from("patch.md"),
-            status: "awaiting_approval".to_string(),
-            requires_approval: true,
-            created_at: Utc::now(),
-        });
-
-        // Simulate approval: update artifact status and add decision
-        let artifact = context
-            .artifacts
-            .iter_mut()
-            .find(|a| a.id == artifact_id)
-            .unwrap();
-        artifact.status = "approved".to_string();
-        context.decisions.push(DecisionRecord {
-            id: "dec-1".to_string(),
-            artifact_id: artifact_id.clone(),
-            decision: "approved_for_future_application".to_string(),
-            approved: true,
-            created_at: Utc::now(),
-        });
-        context.status = "approved".to_string();
-        context.phase = "ready_to_apply".to_string();
-
-        assert_eq!(artifact.status, "approved");
-        assert_eq!(context.status, "approved");
-        assert_eq!(context.decisions.len(), 1);
-        assert!(context.decisions[0].approved);
-    }
-
-    // ── title_from_goal ───────────────────────────────────────────────────
-
-    #[test]
-    fn test_title_from_goal_short() {
-        let title = title_from_goal("Hello");
-        assert_eq!(title, "Hello");
-    }
-
-    #[test]
-    fn test_title_from_goal_truncates_long() {
-        let long = "a".repeat(100);
-        let title = title_from_goal(&long);
-        assert_eq!(title.len(), 51); // 48 + "..."
-        assert!(title.ends_with("..."));
-    }
-
-    // ── looks_like_hardcoded_secret ───────────────────────────────────────
-
-    #[test]
-    fn test_looks_like_hardcoded_secret_detects() {
-        assert!(looks_like_hardcoded_secret("let api_key = \"xxx\""));
-        assert!(looks_like_hardcoded_secret("password = \"hunter2\""));
-        assert!(looks_like_hardcoded_secret("secret = \"s3cr3t\""));
-        assert!(looks_like_hardcoded_secret("token = \"abc\""));
-        assert!(looks_like_hardcoded_secret("apikey = \"xyz\""));
-    }
-
-    #[test]
-    fn test_looks_like_hardcoded_secret_ignores_env() {
-        assert!(!looks_like_hardcoded_secret("api_key = env(\"VAR\")"));
-        assert!(!looks_like_hardcoded_secret("password = \"example\""));
-        assert!(!looks_like_hardcoded_secret("fn main() {}"));
-    }
-
-    // ── normalize_repo_path ───────────────────────────────────────────────
-
-    #[test]
-    fn test_normalize_repo_path_absolute() {
-        let dir = temp_repo();
-        let result = normalize_repo_path(dir.path());
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap().canonicalize().unwrap(),
-            dir.path().canonicalize().unwrap()
-        );
-    }
-
-    #[test]
-    fn test_normalize_repo_path_nonexistent() {
-        let result = normalize_repo_path(Path::new("/nonexistent/path/12345"));
+    fn test_find_context_by_artifact_fails_for_bogus_id() {
+        let result = repo_workbench::find_context_by_artifact("bogus-artifact-id");
         assert!(result.is_err());
-    }
-
-    // ── store_root / paths ────────────────────────────────────────────────
-
-    #[test]
-    fn test_store_root_path() {
-        let p = Path::new("/repo");
-        let root = store_root(p);
-        assert_eq!(root, Path::new("/repo/.prometheos-lite/workbench"));
-    }
-
-    #[test]
-    fn test_contexts_dir_path() {
-        let p = Path::new("/repo");
-        assert_eq!(
-            contexts_dir(p),
-            Path::new("/repo/.prometheos-lite/workbench/contexts")
-        );
-    }
-
-    #[test]
-    fn test_artifacts_dir_path() {
-        let p = Path::new("/repo");
-        assert_eq!(
-            artifacts_dir(p, "wid"),
-            Path::new("/repo/.prometheos-lite/workbench/artifacts/wid")
-        );
-    }
-
-    #[test]
-    fn test_memory_dir_path() {
-        let p = Path::new("/repo");
-        assert_eq!(
-            memory_dir(p),
-            Path::new("/repo/.prometheos-lite/workbench/memory")
-        );
     }
 }

--- a/src/cli/commands/work.rs
+++ b/src/cli/commands/work.rs
@@ -1,13 +1,21 @@
 //! WorkContext CLI commands
+//!
+//! This module supports two paths:
+//! - `work create --repo ...` delegates to the Repo Workbench MVP (file-backed).
+//! - `work create` (without --repo) uses the standard database-backed WorkContextService.
+//! - `work run`, `work artifacts`, `work continue`, `work memory show` detect Repo Workbench
+//!   context IDs by checking the file-backed store and delegate accordingly.
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use prometheos_lite::db::Db;
 use prometheos_lite::flow::RuntimeContext;
 use prometheos_lite::flow::execution_service::FlowExecutionService;
 use prometheos_lite::intent::IntentClassifier;
+use prometheos_lite::repo_workbench;
 use prometheos_lite::work::{
     ExecutionLimits, PlaybookResolver, WorkContextService, WorkOrchestrator,
     evolution_engine::EvolutionEngine,
@@ -26,13 +34,20 @@ pub struct WorkCommand {
 enum WorkSubcommand {
     /// Create a new WorkContext
     Create {
-        /// Title for the work context
-        title: String,
+        /// Title for the work context (required unless --repo is used)
+        title: Option<String>,
         /// Domain of work (software, business, marketing, personal, creative, research, operations, general)
         #[arg(short, long, default_value = "general")]
         domain: String,
         /// Goal description
+        #[arg(short, long)]
         goal: String,
+        /// Repository root to analyze (delegates to Repo Workbench when set)
+        #[arg(long)]
+        repo: Option<PathBuf>,
+        /// Work mode for Repo Workbench (used with --repo)
+        #[arg(long, default_value = "review")]
+        mode: String,
     },
     /// List all WorkContexts
     List,
@@ -77,6 +92,19 @@ enum WorkSubcommand {
         /// New status (draft, in_progress, awaiting_approval, completed, blocked)
         status: String,
     },
+    /// Approve a staged artifact (delegates to Repo Workbench). Records approval only; does not write repo files.
+    Approve {
+        /// Artifact ID
+        artifact_id: String,
+        /// Optional WorkContext ID. If omitted, the current repo store is searched.
+        #[arg(long)]
+        work_id: Option<String>,
+    },
+    /// Inspect persisted Repo Workbench memory
+    Memory {
+        #[command(subcommand)]
+        command: MemorySubcommand,
+    },
     /// Show persisted harness token/cost metrics
     Cost {
         /// WorkContext ID
@@ -99,6 +127,15 @@ enum WorkSubcommand {
     Harness {
         #[command(subcommand)]
         command: HarnessSubcommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum MemorySubcommand {
+    /// Show memory for a Repo Workbench context
+    Show {
+        /// WorkContext ID
+        id: String,
     },
 }
 
@@ -189,7 +226,29 @@ impl WorkCommand {
                 title,
                 domain,
                 goal,
+                repo,
+                mode,
             } => {
+                if let Some(repo) = repo {
+                    let context =
+                        repo_workbench::create_repo_workbench_context(&repo, &goal, &mode, title)?;
+
+                    println!("Created Repo Workbench WorkContext");
+                    println!("  ID: {}", context.id);
+                    println!("  Title: {}", context.title);
+                    println!("  Repo: {}", context.repo_path.display());
+                    println!("  Mode: {}", context.mode);
+                    println!("  Project type: {}", context.repo_summary.project_type);
+                    println!(
+                        "  Candidate files: {}",
+                        context.repo_summary.candidate_files.len()
+                    );
+                    println!("  Next: prometheos work run {}", context.id);
+                    return Ok(());
+                }
+
+                let title = title
+                    .ok_or_else(|| anyhow::anyhow!("Title is required when --repo is not set"))?;
                 let domain = match domain.to_lowercase().as_str() {
                     "software" => WorkDomain::Software,
                     "business" => WorkDomain::Business,
@@ -251,6 +310,26 @@ impl WorkCommand {
                 }
             }
             WorkSubcommand::Artifacts { id } => {
+                if repo_workbench::repo_workbench_context_exists(&id) {
+                    let context = repo_workbench::load_context(&id)?;
+                    println!("Repo Workbench artifacts for {}:", context.id);
+                    if context.artifacts.is_empty() {
+                        println!(
+                            "  No artifacts yet. Run `prometheos work run {}` first.",
+                            context.id
+                        );
+                    }
+                    for artifact in repo_workbench::get_artifacts(&context) {
+                        println!("  {}", artifact.id);
+                        println!("    Title: {}", artifact.title);
+                        println!("    Kind: {}", artifact.kind);
+                        println!("    Status: {}", artifact.status);
+                        println!("    Requires approval: {}", artifact.requires_approval);
+                        println!("    Path: {}", artifact.path.display());
+                    }
+                    return Ok(());
+                }
+
                 let context = work_context_service
                     .get_context(&id)?
                     .ok_or_else(|| anyhow::anyhow!("WorkContext not found"))?;
@@ -288,6 +367,20 @@ impl WorkCommand {
                 println!("  Phase: {:?}", context.current_phase);
             }
             WorkSubcommand::Continue { id } => {
+                if repo_workbench::repo_workbench_context_exists(&id) {
+                    let context = repo_workbench::load_context(&id)?;
+                    println!("Continuing Repo Workbench WorkContext");
+                    repo_workbench::print_status(&context);
+                    println!();
+                    println!("Memory:");
+                    println!("{}", repo_workbench::load_memory(&context)?);
+                    if let Some(next) = &context.next_action {
+                        println!();
+                        println!("Recommended next action: {}", next);
+                    }
+                    return Ok(());
+                }
+
                 let context = work_orchestrator.continue_context(id).await?;
 
                 println!("Continued WorkContext:");
@@ -300,6 +393,35 @@ impl WorkCommand {
                 max_iterations,
                 max_runtime_ms,
             } => {
+                if repo_workbench::repo_workbench_context_exists(&id) {
+                    let mut context = repo_workbench::load_context(&id)?;
+                    repo_workbench::run_repo_workbench_context(&mut context)?;
+
+                    let risk_report = context.artifacts.iter().find(|a| a.kind == "risk-report");
+                    let patch_artifact = context
+                        .artifacts
+                        .iter()
+                        .find(|a| a.kind == "suggested-patch");
+
+                    println!("Repo Workbench run complete");
+                    println!("  WorkContext: {}", context.id);
+                    println!("  Status: {}", context.status);
+                    println!(
+                        "  Files considered: {}",
+                        context.repo_summary.candidate_files.len()
+                    );
+                    if let Some(report) = risk_report {
+                        println!("  Risk report: {}", report.path.display());
+                    }
+                    if let Some(patch) = patch_artifact {
+                        println!("  Suggested patch plan: {}", patch.path.display());
+                    }
+                    if let Some(next) = &context.next_action {
+                        println!("  Next: {}", next);
+                    }
+                    return Ok(());
+                }
+
                 let limits = ExecutionLimits::default()
                     .with_max_iterations(max_iterations.unwrap_or(10))
                     .with_max_runtime_ms(max_runtime_ms.unwrap_or(300_000));
@@ -334,6 +456,30 @@ impl WorkCommand {
 
                 println!("Updated WorkContext status to {:?}", new_status);
             }
+            WorkSubcommand::Approve {
+                artifact_id,
+                work_id,
+            } => {
+                let mut context = if let Some(ref work_id) = work_id {
+                    repo_workbench::load_context(work_id)?
+                } else {
+                    repo_workbench::find_context_by_artifact(&artifact_id)?
+                };
+
+                repo_workbench::approve_artifact(&mut context, &artifact_id)?;
+
+                println!("Approval recorded");
+                println!("  WorkContext: {}", context.id);
+                println!("  Artifact: {}", artifact_id);
+                println!("  Safety: no repository source files were modified");
+                println!("  Next: prometheos work continue {}", context.id);
+            }
+            WorkSubcommand::Memory { command } => match command {
+                MemorySubcommand::Show { id } => {
+                    let context = repo_workbench::load_context(&id)?;
+                    println!("{}", repo_workbench::load_memory(&context)?);
+                }
+            },
             WorkSubcommand::Cost { id } => {
                 let runs = work_context_service.list_harness_run_metrics(&id)?;
                 println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod llm;
 pub mod logger;
 pub mod personality;
 pub mod queue;
+pub mod repo_workbench;
 pub mod runtime_policy;
 pub mod tools;
 pub mod utils;

--- a/src/repo_workbench.rs
+++ b/src/repo_workbench.rs
@@ -1,0 +1,1364 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use uuid::Uuid;
+use walkdir::{DirEntry, WalkDir};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkbenchContext {
+    pub id: String,
+    pub title: String,
+    pub goal: String,
+    pub mode: String,
+    pub repo_path: PathBuf,
+    pub status: String,
+    pub phase: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub repo_summary: RepoSummary,
+    pub artifacts: Vec<ArtifactRef>,
+    pub decisions: Vec<DecisionRecord>,
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RepoSummary {
+    pub project_type: String,
+    pub files_scanned: usize,
+    pub candidate_files: Vec<FileSummary>,
+    pub ignored_dirs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileSummary {
+    pub path: String,
+    pub bytes: u64,
+    pub lines: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactRef {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    pub path: PathBuf,
+    pub status: String,
+    pub requires_approval: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecisionRecord {
+    pub id: String,
+    pub artifact_id: String,
+    pub decision: String,
+    pub approved: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RiskFinding {
+    pub id: String,
+    pub file: String,
+    pub line: usize,
+    pub risk: &'static str,
+    pub category: &'static str,
+    pub summary: String,
+    pub recommendation: String,
+}
+
+pub fn create_repo_workbench_context(
+    repo_path: &Path,
+    goal: &str,
+    mode: &str,
+    title: Option<String>,
+) -> Result<WorkbenchContext> {
+    let repo_path = normalize_repo_path(repo_path)?;
+    let summary = scan_repo(&repo_path)?;
+    let id = Uuid::new_v4().to_string();
+    let now = Utc::now();
+    let title = title.unwrap_or_else(|| title_from_goal(goal));
+    let context = WorkbenchContext {
+        id: id.clone(),
+        title,
+        goal: goal.to_string(),
+        mode: mode.to_string(),
+        repo_path: repo_path.clone(),
+        status: "draft".to_string(),
+        phase: "intake".to_string(),
+        created_at: now,
+        updated_at: now,
+        repo_summary: summary,
+        artifacts: Vec::new(),
+        decisions: Vec::new(),
+        next_action: Some(
+            "Run `prometheos repo run <work_id>` to perform read-only risk review.".to_string(),
+        ),
+    };
+
+    save_context(&context)?;
+    write_memory(&context, &[])?;
+
+    Ok(context)
+}
+
+pub fn run_repo_workbench_context(context: &mut WorkbenchContext) -> Result<()> {
+    context.status = "in_progress".to_string();
+    context.phase = "review".to_string();
+    context.repo_summary = scan_repo(&context.repo_path)?;
+
+    let findings = analyze_risks(&context.repo_path, &context.repo_summary)?;
+    let report = render_risk_report(context, &findings);
+    let patch = render_patch_suggestions(context, &findings);
+
+    let report_artifact = write_artifact(
+        context,
+        "risk-report",
+        "Risk Review Report",
+        "ready",
+        false,
+        &report,
+    )?;
+    let patch_artifact = write_artifact(
+        context,
+        "suggested-patch",
+        "Suggested Patch Plan",
+        "awaiting_approval",
+        true,
+        &patch,
+    )?;
+
+    upsert_artifact(context, report_artifact);
+    upsert_artifact(context, patch_artifact);
+    context.status = "awaiting_approval".to_string();
+    context.phase = "approval".to_string();
+    context.next_action = context
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.requires_approval && artifact.status == "awaiting_approval")
+        .map(|artifact| {
+            format!(
+                "Review `{}` and approve with `prometheos repo approve {}`.",
+                artifact.title, artifact.id
+            )
+        });
+    context.updated_at = Utc::now();
+
+    save_context(context)?;
+    write_memory(context, &findings)?;
+
+    Ok(())
+}
+
+pub fn load_context(id: &str) -> Result<WorkbenchContext> {
+    let repo_path = normalize_repo_path(Path::new("."))?;
+    let path = contexts_dir(&repo_path).join(format!("{}.json", id));
+    let json = fs::read_to_string(&path)
+        .with_context(|| format!("WorkContext `{}` not found at {}", id, path.display()))?;
+    let context = serde_json::from_str(&json)?;
+    Ok(context)
+}
+
+pub fn find_context_by_artifact(artifact_id: &str) -> Result<WorkbenchContext> {
+    let repo_path = normalize_repo_path(Path::new("."))?;
+    let dir = contexts_dir(&repo_path);
+    for entry in fs::read_dir(&dir)
+        .with_context(|| format!("Context directory not found: {}", dir.display()))?
+    {
+        let entry = entry?;
+        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let json = fs::read_to_string(entry.path())?;
+        let context: WorkbenchContext = serde_json::from_str(&json)?;
+        if context
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.id == artifact_id)
+        {
+            return Ok(context);
+        }
+    }
+    anyhow::bail!(
+        "Artifact `{}` not found in current repo workbench store",
+        artifact_id
+    )
+}
+
+pub fn repo_workbench_context_exists(id: &str) -> bool {
+    let Ok(repo_path) = normalize_repo_path(Path::new(".")) else {
+        return false;
+    };
+    let path = contexts_dir(&repo_path).join(format!("{}.json", id));
+    path.exists()
+}
+
+pub fn get_artifacts(context: &WorkbenchContext) -> &[ArtifactRef] {
+    &context.artifacts
+}
+
+pub fn approve_artifact(context: &mut WorkbenchContext, artifact_id: &str) -> Result<()> {
+    let artifact = context
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.id == artifact_id)
+        .with_context(|| format!("Artifact `{}` not found", artifact_id))?;
+
+    if !artifact.requires_approval {
+        println!(
+            "Artifact `{}` does not require approval; recording acknowledgement anyway.",
+            artifact.id
+        );
+    }
+
+    artifact.status = "approved".to_string();
+    context.decisions.push(DecisionRecord {
+        id: Uuid::new_v4().to_string(),
+        artifact_id: artifact_id.to_string(),
+        decision: "approved_for_future_application".to_string(),
+        approved: true,
+        created_at: Utc::now(),
+    });
+    context.status = "approved".to_string();
+    context.phase = "ready_to_apply".to_string();
+    context.next_action = Some(
+        "Approval recorded. MVP does not apply patches automatically; future writer must consume the approved artifact explicitly."
+            .to_string(),
+    );
+    context.updated_at = Utc::now();
+    save_context(context)?;
+    write_memory(context, &[])?;
+    Ok(())
+}
+
+pub fn load_memory(context: &WorkbenchContext) -> Result<String> {
+    let path = memory_dir(&context.repo_path).join(format!("{}.md", context.id));
+    fs::read_to_string(&path).with_context(|| format!("Memory not found at {}", path.display()))
+}
+
+pub fn print_status(context: &WorkbenchContext) {
+    println!("Repo Workbench WorkContext");
+    println!("  ID: {}", context.id);
+    println!("  Title: {}", context.title);
+    println!("  Goal: {}", context.goal);
+    println!("  Repo: {}", context.repo_path.display());
+    println!("  Status: {}", context.status);
+    println!("  Phase: {}", context.phase);
+    println!("  Project type: {}", context.repo_summary.project_type);
+    println!(
+        "  Candidate files: {}",
+        context.repo_summary.candidate_files.len()
+    );
+    println!("  Artifacts: {}", context.artifacts.len());
+    println!("  Decisions: {}", context.decisions.len());
+    if let Some(next) = &context.next_action {
+        println!("  Next: {}", next);
+    }
+}
+
+fn normalize_repo_path(repo: &Path) -> Result<PathBuf> {
+    let path = if repo.is_absolute() {
+        repo.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(repo)
+    };
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("Repository path does not exist: {}", path.display()))?;
+    if !path.is_dir() {
+        anyhow::bail!("Repository path is not a directory: {}", path.display());
+    }
+    Ok(path)
+}
+
+fn title_from_goal(goal: &str) -> String {
+    let trimmed = goal.trim();
+    if trimmed.len() <= 48 {
+        return trimmed.to_string();
+    }
+    format!("{}...", &trimmed[..48])
+}
+
+fn store_root(repo_path: &Path) -> PathBuf {
+    repo_path.join(".prometheos-lite").join("workbench")
+}
+
+fn contexts_dir(repo_path: &Path) -> PathBuf {
+    store_root(repo_path).join("contexts")
+}
+
+fn artifacts_dir(repo_path: &Path, work_id: &str) -> PathBuf {
+    store_root(repo_path).join("artifacts").join(work_id)
+}
+
+fn memory_dir(repo_path: &Path) -> PathBuf {
+    store_root(repo_path).join("memory")
+}
+
+fn context_path(context: &WorkbenchContext) -> PathBuf {
+    contexts_dir(&context.repo_path).join(format!("{}.json", context.id))
+}
+
+fn save_context(context: &WorkbenchContext) -> Result<()> {
+    fs::create_dir_all(contexts_dir(&context.repo_path))?;
+    let json = serde_json::to_string_pretty(context)?;
+    fs::write(context_path(context), json)?;
+    Ok(())
+}
+
+fn scan_repo(repo_path: &Path) -> Result<RepoSummary> {
+    let mut files = Vec::new();
+    let mut ignored_dirs = vec![
+        ".git".to_string(),
+        "target".to_string(),
+        "node_modules".to_string(),
+        "dist".to_string(),
+        "build".to_string(),
+        ".prometheos-lite".to_string(),
+    ];
+
+    for entry in WalkDir::new(repo_path)
+        .into_iter()
+        .filter_entry(|entry| !is_ignored(entry))
+        .filter_map(|entry| entry.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if !is_candidate_file(path) {
+            continue;
+        }
+        let metadata = fs::metadata(path)?;
+        if metadata.len() > 200_000 {
+            continue;
+        }
+        let content = fs::read_to_string(path).unwrap_or_default();
+        let relative = path
+            .strip_prefix(repo_path)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        files.push(FileSummary {
+            path: relative,
+            bytes: metadata.len(),
+            lines: content.lines().count(),
+        });
+        if files.len() >= 80 {
+            break;
+        }
+    }
+
+    ignored_dirs.sort();
+    ignored_dirs.dedup();
+
+    Ok(RepoSummary {
+        project_type: detect_project_type(repo_path),
+        files_scanned: files.len(),
+        candidate_files: files,
+        ignored_dirs,
+    })
+}
+
+fn is_ignored(entry: &DirEntry) -> bool {
+    let name = entry.file_name().to_string_lossy();
+    matches!(
+        name.as_ref(),
+        ".git" | "target" | "node_modules" | "dist" | "build" | ".prometheos-lite"
+    )
+}
+
+fn is_candidate_file(path: &Path) -> bool {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if matches!(
+        file_name,
+        "Cargo.toml" | "package.json" | "pyproject.toml" | "go.mod" | "README.md"
+    ) {
+        return true;
+    }
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some(
+            "rs" | "ts"
+                | "tsx"
+                | "js"
+                | "jsx"
+                | "py"
+                | "go"
+                | "java"
+                | "cpp"
+                | "c"
+                | "h"
+                | "toml"
+                | "yaml"
+                | "yml"
+        )
+    )
+}
+
+fn detect_project_type(repo_path: &Path) -> String {
+    if repo_path.join("Cargo.toml").exists() {
+        "rust".to_string()
+    } else if repo_path.join("package.json").exists() {
+        "node".to_string()
+    } else if repo_path.join("pyproject.toml").exists()
+        || repo_path.join("requirements.txt").exists()
+    {
+        "python".to_string()
+    } else if repo_path.join("go.mod").exists() {
+        "go".to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn analyze_risks(repo_path: &Path, summary: &RepoSummary) -> Result<Vec<RiskFinding>> {
+    let mut findings = Vec::new();
+
+    for file in &summary.candidate_files {
+        let path = repo_path.join(&file.path);
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for (idx, line) in content.lines().enumerate() {
+            let line_number = idx + 1;
+            let lower = line.to_lowercase();
+
+            let finding = if line.contains(".unwrap()") || line.contains("unwrap(") {
+                Some((
+                    "Medium",
+                    "panic-risk",
+                    "Potential panic from unwrap".to_string(),
+                    "Replace unwrap with structured error handling or a safe fallback.".to_string(),
+                ))
+            } else if line.contains(".expect(") || line.contains("panic!(") {
+                Some((
+                    "Medium",
+                    "panic-risk",
+                    "Explicit panic path in application code".to_string(),
+                    "Return a typed error or convert the panic into a controlled failure path."
+                        .to_string(),
+                ))
+            } else if lower.contains("todo!") || lower.contains("fixme") || lower.contains("todo:")
+            {
+                Some((
+                    "Low",
+                    "unfinished-work",
+                    "Unfinished implementation marker".to_string(),
+                    "Convert the marker into a tracked task or complete the implementation before release.".to_string(),
+                ))
+            } else if looks_like_hardcoded_secret(&lower) {
+                Some((
+                    "High",
+                    "secret-risk",
+                    "Possible hardcoded secret or credential".to_string(),
+                    "Move the value into environment-backed configuration or a secret manager."
+                        .to_string(),
+                ))
+            } else if lower.contains("eval(") {
+                Some((
+                    "High",
+                    "code-execution-risk",
+                    "Dynamic eval call detected".to_string(),
+                    "Avoid eval or strictly constrain and validate input before execution."
+                        .to_string(),
+                ))
+            } else if lower.contains("shell=true") {
+                Some((
+                    "High",
+                    "command-injection-risk",
+                    "Shell execution with shell=True detected".to_string(),
+                    "Use argument arrays and avoid shell interpolation for subprocess execution."
+                        .to_string(),
+                ))
+            } else if lower.contains("innerhtml") {
+                Some((
+                    "Medium",
+                    "xss-risk",
+                    "Direct innerHTML usage detected".to_string(),
+                    "Prefer safe DOM APIs or sanitize trusted markup before insertion.".to_string(),
+                ))
+            } else {
+                None
+            };
+
+            if let Some((risk, category, summary, recommendation)) = finding {
+                findings.push(RiskFinding {
+                    id: format!("F-{:03}", findings.len() + 1),
+                    file: file.path.clone(),
+                    line: line_number,
+                    risk,
+                    category,
+                    summary,
+                    recommendation,
+                });
+            }
+        }
+    }
+
+    Ok(findings)
+}
+
+fn looks_like_hardcoded_secret(lower: &str) -> bool {
+    let mentions_secret = ["api_key", "apikey", "secret", "password", "token"]
+        .iter()
+        .any(|needle| lower.contains(needle));
+    mentions_secret && lower.contains('=') && !lower.contains("env") && !lower.contains("example")
+}
+
+fn render_risk_report(context: &WorkbenchContext, findings: &[RiskFinding]) -> String {
+    let mut out = String::new();
+    out.push_str("# Risk Review\n\n");
+    out.push_str("## Summary\n\n");
+    out.push_str(&format!(
+        "PrometheOS Lite reviewed `{}` and found {} risk finding(s) across {} candidate file(s).\n\n",
+        context.repo_path.display(),
+        findings.len(),
+        context.repo_summary.candidate_files.len()
+    ));
+    out.push_str("## WorkContext\n\n");
+    out.push_str(&format!("- ID: `{}`\n", context.id));
+    out.push_str(&format!("- Goal: {}\n", context.goal));
+    out.push_str(&format!("- Mode: {}\n", context.mode));
+    out.push_str(&format!(
+        "- Project type: {}\n\n",
+        context.repo_summary.project_type
+    ));
+
+    if findings.is_empty() {
+        out.push_str("## Findings\n\nNo obvious risky patterns were found by the MVP heuristic scanner. This does not mean the repo is safe; it means the boring little scanner did not catch anything obvious.\n");
+        return out;
+    }
+
+    out.push_str("## Findings\n\n");
+    for finding in findings {
+        out.push_str(&format!("### {}. {}\n\n", finding.id, finding.summary));
+        out.push_str(&format!("- File: `{}`\n", finding.file));
+        out.push_str(&format!("- Line: {}\n", finding.line));
+        out.push_str(&format!("- Risk: {}\n", finding.risk));
+        out.push_str(&format!("- Category: {}\n", finding.category));
+        out.push_str(&format!("- Suggested fix: {}\n\n", finding.recommendation));
+    }
+
+    out
+}
+
+fn render_patch_suggestions(context: &WorkbenchContext, findings: &[RiskFinding]) -> String {
+    let mut out = String::new();
+    out.push_str("# Suggested Patch Plan\n\n");
+    out.push_str("> Safety note: this MVP artifact is a staged suggestion only. No repository files were modified.\n\n");
+    out.push_str(&format!("WorkContext: `{}`\n\n", context.id));
+
+    if findings.is_empty() {
+        out.push_str("No patch suggestions were generated because the MVP risk scanner found no obvious risky patterns.\n");
+        return out;
+    }
+
+    out.push_str("## Recommended Changes\n\n");
+    for finding in findings.iter().take(20) {
+        out.push_str(&format!(
+            "### {}: `{}` line {}\n\n",
+            finding.id, finding.file, finding.line
+        ));
+        out.push_str(&format!(
+            "Risk: {} / {}\n\n",
+            finding.risk, finding.category
+        ));
+        out.push_str(&format!("Suggested change: {}\n\n", finding.recommendation));
+    }
+
+    out.push_str("## Approval\n\n");
+    out.push_str("Approve this artifact when the suggestions are acceptable. The current MVP records approval only; an explicit future writer must apply changes.\n");
+    out
+}
+
+fn write_artifact(
+    context: &WorkbenchContext,
+    kind: &str,
+    title: &str,
+    status: &str,
+    requires_approval: bool,
+    content: &str,
+) -> Result<ArtifactRef> {
+    let id = Uuid::new_v4().to_string();
+    let dir = artifacts_dir(&context.repo_path, &context.id);
+    fs::create_dir_all(&dir)?;
+    let filename = format!("{}-{}.md", kind, &id[..8]);
+    let path = dir.join(filename);
+    fs::write(&path, content)?;
+    Ok(ArtifactRef {
+        id,
+        kind: kind.to_string(),
+        title: title.to_string(),
+        path,
+        status: status.to_string(),
+        requires_approval,
+        created_at: Utc::now(),
+    })
+}
+
+fn upsert_artifact(context: &mut WorkbenchContext, artifact: ArtifactRef) {
+    context
+        .artifacts
+        .retain(|existing| existing.kind != artifact.kind);
+    context.artifacts.push(artifact);
+}
+
+fn write_memory(context: &WorkbenchContext, findings: &[RiskFinding]) -> Result<()> {
+    fs::create_dir_all(memory_dir(&context.repo_path))?;
+    let mut out = String::new();
+    out.push_str("# Repo Workbench Memory\n\n");
+    out.push_str(&format!("- WorkContext: `{}`\n", context.id));
+    out.push_str(&format!("- Title: {}\n", context.title));
+    out.push_str(&format!("- Goal: {}\n", context.goal));
+    out.push_str(&format!("- Repo: `{}`\n", context.repo_path.display()));
+    out.push_str(&format!("- Status: {}\n", context.status));
+    out.push_str(&format!("- Phase: {}\n", context.phase));
+    out.push_str(&format!(
+        "- Project type: {}\n",
+        context.repo_summary.project_type
+    ));
+    out.push_str(&format!(
+        "- Candidate files: {}\n",
+        context.repo_summary.candidate_files.len()
+    ));
+    out.push_str(&format!("- Artifacts: {}\n", context.artifacts.len()));
+    out.push_str(&format!("- Decisions: {}\n", context.decisions.len()));
+    if let Some(next) = &context.next_action {
+        out.push_str(&format!("- Next action: {}\n", next));
+    }
+
+    if !findings.is_empty() {
+        out.push_str("\n## Latest Findings\n\n");
+        for finding in findings.iter().take(20) {
+            out.push_str(&format!(
+                "- {} `{}`:{} [{}] {}\n",
+                finding.id, finding.file, finding.line, finding.risk, finding.summary
+            ));
+        }
+    }
+
+    if !context.artifacts.is_empty() {
+        out.push_str("\n## Artifacts\n\n");
+        for artifact in &context.artifacts {
+            out.push_str(&format!(
+                "- `{}` {} ({}, status: {}, approval: {}) at `{}`\n",
+                artifact.id,
+                artifact.title,
+                artifact.kind,
+                artifact.status,
+                artifact.requires_approval,
+                artifact.path.display()
+            ));
+        }
+    }
+
+    fs::write(
+        memory_dir(&context.repo_path).join(format!("{}.md", context.id)),
+        out,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn temp_repo() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    fn write_file(dir: &Path, relative: &str, content: &str) {
+        let path = dir.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, content).unwrap();
+    }
+
+    fn make_context(repo_path: &Path) -> WorkbenchContext {
+        WorkbenchContext {
+            id: "test-id".to_string(),
+            title: "Test".to_string(),
+            goal: "Find issues".to_string(),
+            mode: "review".to_string(),
+            repo_path: repo_path.to_path_buf(),
+            status: "draft".to_string(),
+            phase: "intake".to_string(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            repo_summary: RepoSummary::default(),
+            artifacts: Vec::new(),
+            decisions: Vec::new(),
+            next_action: None,
+        }
+    }
+
+    // ── scan_repo ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_scan_repo_ignores_ignored_dirs() {
+        let dir = temp_repo();
+        let root = dir.path();
+
+        write_file(root, "Cargo.toml", "[package]\nname = \"test\"\n");
+        write_file(root, ".git/HEAD", "ref: refs/heads/main\n");
+        write_file(root, "target/debug/test.o", "");
+        write_file(root, "node_modules/pkg/index.js", "// dep");
+        write_file(root, ".prometheos-lite/workbench/contexts/test.json", "{}");
+
+        let summary = scan_repo(root).unwrap();
+        let paths: Vec<&str> = summary
+            .candidate_files
+            .iter()
+            .map(|f| f.path.as_str())
+            .collect();
+        assert!(
+            paths.contains(&"Cargo.toml"),
+            "Cargo.toml should be scanned"
+        );
+        assert!(
+            !paths.iter().any(|p| p.contains(".git")),
+            ".git should be ignored"
+        );
+        assert!(
+            !paths.iter().any(|p| p.contains("target/")),
+            "target should be ignored"
+        );
+        assert!(
+            !paths.iter().any(|p| p.contains("node_modules/")),
+            "node_modules should be ignored"
+        );
+        assert!(
+            !paths.iter().any(|p| p.contains(".prometheos-lite")),
+            ".prometheos-lite should be ignored"
+        );
+    }
+
+    // ── detect_project_type ───────────────────────────────────────────────
+
+    #[test]
+    fn test_detect_project_type_rust() {
+        let dir = temp_repo();
+        write_file(dir.path(), "Cargo.toml", "[package]\n");
+        assert_eq!(detect_project_type(dir.path()), "rust");
+    }
+
+    #[test]
+    fn test_detect_project_type_node() {
+        let dir = temp_repo();
+        write_file(dir.path(), "package.json", "{}");
+        assert_eq!(detect_project_type(dir.path()), "node");
+    }
+
+    #[test]
+    fn test_detect_project_type_python_pyproject() {
+        let dir = temp_repo();
+        write_file(dir.path(), "pyproject.toml", "[project]\n");
+        assert_eq!(detect_project_type(dir.path()), "python");
+    }
+
+    #[test]
+    fn test_detect_project_type_python_requirements() {
+        let dir = temp_repo();
+        write_file(dir.path(), "requirements.txt", "requests\n");
+        assert_eq!(detect_project_type(dir.path()), "python");
+    }
+
+    #[test]
+    fn test_detect_project_type_go() {
+        let dir = temp_repo();
+        write_file(dir.path(), "go.mod", "module test\n");
+        assert_eq!(detect_project_type(dir.path()), "go");
+    }
+
+    #[test]
+    fn test_detect_project_type_unknown() {
+        let dir = temp_repo();
+        assert_eq!(detect_project_type(dir.path()), "unknown");
+    }
+
+    // ── is_candidate_file ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_candidate_file_extensions() {
+        assert!(is_candidate_file_inner("main.rs"));
+        assert!(is_candidate_file_inner("lib.ts"));
+        assert!(is_candidate_file_inner("app.tsx"));
+        assert!(is_candidate_file_inner("index.js"));
+        assert!(is_candidate_file_inner("app.jsx"));
+        assert!(is_candidate_file_inner("script.py"));
+        assert!(is_candidate_file_inner("main.go"));
+        assert!(is_candidate_file_inner("App.java"));
+        assert!(is_candidate_file_inner("lib.cpp"));
+        assert!(is_candidate_file_inner("lib.c"));
+        assert!(is_candidate_file_inner("lib.h"));
+        assert!(is_candidate_file_inner("conf.toml"));
+        assert!(is_candidate_file_inner("config.yaml"));
+        assert!(is_candidate_file_inner("config.yml"));
+        assert!(!is_candidate_file_inner("image.png"));
+        assert!(!is_candidate_file_inner("data.json"));
+        assert!(!is_candidate_file_inner("file.md"));
+    }
+
+    #[test]
+    fn test_is_candidate_file_special_names() {
+        assert!(is_candidate_file_inner("Cargo.toml"));
+        assert!(is_candidate_file_inner("package.json"));
+        assert!(is_candidate_file_inner("pyproject.toml"));
+        assert!(is_candidate_file_inner("go.mod"));
+        assert!(is_candidate_file_inner("README.md"));
+    }
+
+    fn is_candidate_file_inner(name: &str) -> bool {
+        let path = Path::new(name);
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if matches!(
+            file_name,
+            "Cargo.toml" | "package.json" | "pyproject.toml" | "go.mod" | "README.md"
+        ) {
+            return true;
+        }
+        matches!(
+            path.extension().and_then(|ext| ext.to_str()),
+            Some(
+                "rs" | "ts"
+                    | "tsx"
+                    | "js"
+                    | "jsx"
+                    | "py"
+                    | "go"
+                    | "java"
+                    | "cpp"
+                    | "c"
+                    | "h"
+                    | "toml"
+                    | "yaml"
+                    | "yml"
+            )
+        )
+    }
+
+    // ── analyze_risks ─────────────────────────────────────────────────────
+
+    fn make_summary_with_file(repo_path: &Path, relative: &str) -> RepoSummary {
+        let metadata = fs::metadata(repo_path.join(relative)).unwrap();
+        RepoSummary {
+            project_type: "rust".to_string(),
+            files_scanned: 1,
+            candidate_files: vec![FileSummary {
+                path: relative.to_string(),
+                bytes: metadata.len(),
+                lines: fs::read_to_string(repo_path.join(relative))
+                    .unwrap()
+                    .lines()
+                    .count(),
+            }],
+            ignored_dirs: vec![],
+        }
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_unwrap() {
+        let dir = temp_repo();
+        write_file(
+            dir.path(),
+            "src/main.rs",
+            "fn main() { let x = data.unwrap(); }",
+        );
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.summary.contains("unwrap")),
+            "should detect unwrap"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_expect() {
+        let dir = temp_repo();
+        write_file(
+            dir.path(),
+            "src/main.rs",
+            "fn main() { let x = data.expect(\"msg\"); }",
+        );
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.summary.contains("panic")),
+            "should detect expect"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_panic() {
+        let dir = temp_repo();
+        write_file(dir.path(), "src/main.rs", "fn main() { panic!(\"boom\"); }");
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.summary.contains("panic")),
+            "should detect panic"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_todo_marker() {
+        let dir = temp_repo();
+        write_file(dir.path(), "src/main.rs", "fn main() { let _ = todo! }");
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.category == "unfinished-work"),
+            "should detect todo marker"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_fixme_marker() {
+        let dir = temp_repo();
+        write_file(dir.path(), "src/main.rs", "fn main() { let _ = fixme }");
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.category == "unfinished-work"),
+            "should detect fixme marker"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_hardcoded_secret() {
+        let dir = temp_repo();
+        write_file(
+            dir.path(),
+            "src/main.rs",
+            "fn main() { let api_key = \"sk-123\"; }",
+        );
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.category == "secret-risk"),
+            "should detect hardcoded secret"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_eval() {
+        let dir = temp_repo();
+        write_file(dir.path(), "src/main.rs", "fn main() { eval(user_input); }");
+        let summary = make_summary_with_file(dir.path(), "src/main.rs");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.category == "code-execution-risk"),
+            "should detect eval"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_shell_true() {
+        let dir = temp_repo();
+        write_file(dir.path(), "script.py", "subprocess.run(cmd, shell=True)");
+        let summary = make_summary_with_file(dir.path(), "script.py");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.category == "command-injection-risk"),
+            "should detect shell=True"
+        );
+    }
+
+    #[test]
+    fn test_analyze_risks_detects_innerhtml() {
+        let dir = temp_repo();
+        write_file(
+            dir.path(),
+            "app.js",
+            "document.getElementById('x').innerHTML = html;",
+        );
+        let summary = make_summary_with_file(dir.path(), "app.js");
+        let findings = analyze_risks(dir.path(), &summary).unwrap();
+        assert!(
+            findings.iter().any(|f| f.category == "xss-risk"),
+            "should detect innerHTML"
+        );
+    }
+
+    // ── render_risk_report ───────────────────────────────────────────────
+
+    #[test]
+    fn test_render_risk_report_creates_output() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let findings = vec![RiskFinding {
+            id: "F-001".to_string(),
+            file: "src/main.rs".to_string(),
+            line: 5,
+            risk: "Medium",
+            category: "panic-risk",
+            summary: "Potential panic from unwrap".to_string(),
+            recommendation: "Replace unwrap".to_string(),
+        }];
+        let report = render_risk_report(&context, &findings);
+        assert!(report.contains("# Risk Review"), "should have title");
+        assert!(report.contains("F-001"), "should contain finding ID");
+        assert!(report.contains("Potential panic"), "should contain summary");
+    }
+
+    #[test]
+    fn test_render_risk_report_empty() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let report = render_risk_report(&context, &[]);
+        assert!(
+            report.contains("No obvious risky patterns"),
+            "empty case message"
+        );
+    }
+
+    // ── render_patch_suggestions ──────────────────────────────────────────
+
+    #[test]
+    fn test_render_patch_suggestions_creates_output() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let findings = vec![RiskFinding {
+            id: "F-001".to_string(),
+            file: "src/main.rs".to_string(),
+            line: 5,
+            risk: "Medium",
+            category: "panic-risk",
+            summary: "Potential panic".to_string(),
+            recommendation: "Replace with error handling".to_string(),
+        }];
+        let patch = render_patch_suggestions(&context, &findings);
+        assert!(
+            patch.contains("# Suggested Patch Plan"),
+            "should have title"
+        );
+        assert!(patch.contains("F-001"), "should contain finding ID");
+        assert!(patch.contains("Approval"), "should mention approval");
+    }
+
+    #[test]
+    fn test_render_patch_suggestions_empty() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let patch = render_patch_suggestions(&context, &[]);
+        assert!(patch.contains("No patch suggestions"), "empty case message");
+    }
+
+    // ── write_artifact ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_write_artifact_creates_file() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let artifact = write_artifact(
+            &context,
+            "risk-report",
+            "Test Report",
+            "ready",
+            false,
+            "# Report",
+        )
+        .unwrap();
+        assert!(artifact.path.exists(), "artifact file should exist on disk");
+        let content = fs::read_to_string(&artifact.path).unwrap();
+        assert_eq!(content.trim(), "# Report");
+        assert_eq!(artifact.kind, "risk-report");
+        assert_eq!(artifact.status, "ready");
+        assert!(!artifact.requires_approval);
+    }
+
+    #[test]
+    fn test_write_artifact_requires_approval() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let artifact = write_artifact(
+            &context,
+            "suggested-patch",
+            "Patch",
+            "awaiting_approval",
+            true,
+            "# Patch",
+        )
+        .unwrap();
+        assert!(artifact.requires_approval);
+        assert_eq!(artifact.status, "awaiting_approval");
+    }
+
+    // ── upsert_artifact ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_upsert_artifact_replaces_by_kind() {
+        let mut context = make_context(Path::new("/tmp"));
+        let a1 = ArtifactRef {
+            id: "id-1".to_string(),
+            kind: "risk-report".to_string(),
+            title: "Old".to_string(),
+            path: PathBuf::from("/tmp/a.md"),
+            status: "ready".to_string(),
+            requires_approval: false,
+            created_at: Utc::now(),
+        };
+        let a2 = ArtifactRef {
+            id: "id-2".to_string(),
+            kind: "risk-report".to_string(),
+            title: "New".to_string(),
+            path: PathBuf::from("/tmp/b.md"),
+            status: "ready".to_string(),
+            requires_approval: false,
+            created_at: Utc::now(),
+        };
+        context.artifacts.push(a1);
+        upsert_artifact(&mut context, a2);
+        assert_eq!(
+            context.artifacts.len(),
+            1,
+            "old artifact should be replaced"
+        );
+        assert_eq!(
+            context.artifacts[0].id, "id-2",
+            "new artifact should be present"
+        );
+    }
+
+    #[test]
+    fn test_upsert_artifact_appends_different_kind() {
+        let mut context = make_context(Path::new("/tmp"));
+        let a1 = ArtifactRef {
+            id: "id-1".to_string(),
+            kind: "risk-report".to_string(),
+            title: "Report".to_string(),
+            path: PathBuf::from("/tmp/a.md"),
+            status: "ready".to_string(),
+            requires_approval: false,
+            created_at: Utc::now(),
+        };
+        let a2 = ArtifactRef {
+            id: "id-2".to_string(),
+            kind: "suggested-patch".to_string(),
+            title: "Patch".to_string(),
+            path: PathBuf::from("/tmp/b.md"),
+            status: "awaiting_approval".to_string(),
+            requires_approval: true,
+            created_at: Utc::now(),
+        };
+        context.artifacts.push(a1);
+        upsert_artifact(&mut context, a2);
+        assert_eq!(
+            context.artifacts.len(),
+            2,
+            "different kinds should both be present"
+        );
+    }
+
+    // ── write_memory ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_write_memory_includes_required_fields() {
+        let dir = temp_repo();
+        let mut context = make_context(dir.path());
+        context.id = "mem-test-id".to_string();
+        context.goal = "Find issues".to_string();
+        context.status = "awaiting_approval".to_string();
+        context.next_action = Some("Approve the patch".to_string());
+        context.artifacts.push(ArtifactRef {
+            id: "art-1".to_string(),
+            kind: "risk-report".to_string(),
+            title: "Report".to_string(),
+            path: PathBuf::from("report.md"),
+            status: "ready".to_string(),
+            requires_approval: false,
+            created_at: Utc::now(),
+        });
+
+        write_memory(&context, &[]).unwrap();
+
+        let memory_path = memory_dir(dir.path()).join("mem-test-id.md");
+        assert!(memory_path.exists(), "memory file should exist");
+        let content = fs::read_to_string(&memory_path).unwrap();
+        assert!(
+            content.contains("mem-test-id"),
+            "should contain work context ID"
+        );
+        assert!(content.contains("Find issues"), "should contain goal");
+        assert!(
+            content.contains(&dir.path().to_string_lossy().to_string()),
+            "should contain repo path"
+        );
+        assert!(
+            content.contains("awaiting_approval"),
+            "should contain status"
+        );
+        assert!(content.contains("Report"), "should contain artifact info");
+        assert!(
+            content.contains("Approve the patch"),
+            "should contain next action"
+        );
+    }
+
+    #[test]
+    fn test_write_memory_with_findings() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let findings = vec![RiskFinding {
+            id: "F-001".to_string(),
+            file: "src/main.rs".to_string(),
+            line: 5,
+            risk: "Medium",
+            category: "panic-risk",
+            summary: "Potential panic".to_string(),
+            recommendation: "Fix it".to_string(),
+        }];
+        write_memory(&context, &findings).unwrap();
+        let memory_path = memory_dir(dir.path()).join("test-id.md");
+        let content = fs::read_to_string(&memory_path).unwrap();
+        assert!(content.contains("F-001"), "should contain finding ID");
+        assert!(
+            content.contains("Potential panic"),
+            "should contain finding summary"
+        );
+    }
+
+    // ── approve flow ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_approve_updates_status() {
+        let dir = temp_repo();
+        let mut context = make_context(dir.path());
+        let artifact_id = "approve-test-id".to_string();
+        context.artifacts.push(ArtifactRef {
+            id: artifact_id.clone(),
+            kind: "suggested-patch".to_string(),
+            title: "Patch".to_string(),
+            path: PathBuf::from("patch.md"),
+            status: "awaiting_approval".to_string(),
+            requires_approval: true,
+            created_at: Utc::now(),
+        });
+
+        let artifact = context
+            .artifacts
+            .iter_mut()
+            .find(|a| a.id == artifact_id)
+            .unwrap();
+        artifact.status = "approved".to_string();
+        context.decisions.push(DecisionRecord {
+            id: "dec-1".to_string(),
+            artifact_id: artifact_id.clone(),
+            decision: "approved_for_future_application".to_string(),
+            approved: true,
+            created_at: Utc::now(),
+        });
+        context.status = "approved".to_string();
+        context.phase = "ready_to_apply".to_string();
+
+        assert_eq!(artifact.status, "approved");
+        assert_eq!(context.status, "approved");
+        assert_eq!(context.decisions.len(), 1);
+        assert!(context.decisions[0].approved);
+    }
+
+    // ── title_from_goal ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_title_from_goal_short() {
+        let title = title_from_goal("Hello");
+        assert_eq!(title, "Hello");
+    }
+
+    #[test]
+    fn test_title_from_goal_truncates_long() {
+        let long = "a".repeat(100);
+        let title = title_from_goal(&long);
+        assert_eq!(title.len(), 51);
+        assert!(title.ends_with("..."));
+    }
+
+    // ── looks_like_hardcoded_secret ───────────────────────────────────────
+
+    #[test]
+    fn test_looks_like_hardcoded_secret_detects() {
+        assert!(looks_like_hardcoded_secret("let api_key = \"xxx\""));
+        assert!(looks_like_hardcoded_secret("password = \"hunter2\""));
+        assert!(looks_like_hardcoded_secret("secret = \"s3cr3t\""));
+        assert!(looks_like_hardcoded_secret("token = \"abc\""));
+        assert!(looks_like_hardcoded_secret("apikey = \"xyz\""));
+    }
+
+    #[test]
+    fn test_looks_like_hardcoded_secret_ignores_env() {
+        assert!(!looks_like_hardcoded_secret("api_key = env(\"VAR\")"));
+        assert!(!looks_like_hardcoded_secret("password = \"example\""));
+        assert!(!looks_like_hardcoded_secret("fn main() {}"));
+    }
+
+    // ── normalize_repo_path ───────────────────────────────────────────────
+
+    #[test]
+    fn test_normalize_repo_path_absolute() {
+        let dir = temp_repo();
+        let result = normalize_repo_path(dir.path());
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap().canonicalize().unwrap(),
+            dir.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_normalize_repo_path_nonexistent() {
+        let result = normalize_repo_path(Path::new("/nonexistent/path/12345"));
+        assert!(result.is_err());
+    }
+
+    // ── store_root / paths ────────────────────────────────────────────────
+
+    #[test]
+    fn test_store_root_path() {
+        let p = Path::new("/repo");
+        let root = store_root(p);
+        assert_eq!(root, Path::new("/repo/.prometheos-lite/workbench"));
+    }
+
+    #[test]
+    fn test_contexts_dir_path() {
+        let p = Path::new("/repo");
+        assert_eq!(
+            contexts_dir(p),
+            Path::new("/repo/.prometheos-lite/workbench/contexts")
+        );
+    }
+
+    #[test]
+    fn test_artifacts_dir_path() {
+        let p = Path::new("/repo");
+        assert_eq!(
+            artifacts_dir(p, "wid"),
+            Path::new("/repo/.prometheos-lite/workbench/artifacts/wid")
+        );
+    }
+
+    #[test]
+    fn test_memory_dir_path() {
+        let p = Path::new("/repo");
+        assert_eq!(
+            memory_dir(p),
+            Path::new("/repo/.prometheos-lite/workbench/memory")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds \prometheos work ...\ compatibility for the Repo Workbench MVP.

The Repo Workbench golden path can now be accessed through the product-facing \work\ command surface while keeping the existing \epo\ command available.

## What changed

- Extracted reusable service functions into \src/repo_workbench.rs\ (lib module)
- Added \work create --repo ...\ delegation to Repo Workbench
- \work run\, \work artifacts\, \work continue\, \work memory show\ detect Repo Workbench context IDs via file-backed store check
- Added \work approve <artifact_id>\ for Repo Workbench approval recording
- Both \epo\ and \work\ commands share the same implementation
- Updated docs to show product-facing \work\ commands alongside legacy \epo\ path

## Safety model

This PR keeps the Repo Workbench MVP read-only toward repository source files.

\un\ only analyzes files and writes artifacts/memory under \.prometheos-lite/workbench/\.

\pprove\ records approval only. It does not apply patches.

## Verification

- [x] \cargo fmt --check\ passes
- [x] \cargo check\ passes
- [x] \cargo test\ passes (all 800+ tests)
- [x] \cargo clippy --all-targets --all-features -- -D warnings\ passes

## Follow-ups

- Move Repo Workbench storage into the existing WorkContext service after this compatibility path is stable
- Add CI coverage for the exact \prometheos work ...\ golden path
- Add optional patch application behind a separate explicit command later