### PR TITLE
MVP: zero-to-first-value quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,43 +203,23 @@ let artifact = execution_service
     .await?;
 ```
 
-### 7. Repo Workbench MVP Quickstart
+### 7. Zero-to-First-Value
 
-The Repo Workbench can be accessed through two command surfaces:
-
-**Product-facing path (preferred):**
+Run PrometheOS Lite against the included risky Rust fixture:
 
 ```bash
 cargo run -- work create \
-  --repo . \
+  --repo fixtures/repo-workbench/rust-risky \
   --goal "Find risky code and suggest safe improvements" \
   --mode review
 
 cargo run -- work run <work_id>
 cargo run -- work artifacts <work_id>
-cargo run -- work approve <artifact_id>
 cargo run -- work memory show <work_id>
 cargo run -- work continue <work_id>
 ```
 
-**Legacy path (same implementation):**
-
-```bash
-cargo run -- repo create \
-  --repo . \
-  --goal "Find risky code and suggest safe improvements" \
-  --mode review
-
-cargo run -- repo run <work_id>
-cargo run -- repo artifacts <work_id>
-cargo run -- repo approve <artifact_id>
-cargo run -- repo memory show <work_id>
-cargo run -- repo continue <work_id>
-```
-
-Both surfaces share the same implementation. The Repo Workbench is a local-first, file-backed MVP that scans a repository for risky code patterns, generates a risk report and suggested patch plan, requires explicit approval, and persists memory for continuation.
-
-See [docs/guides/repo-workbench-mvp.md](docs/guides/repo-workbench-mvp.md) for the full guide.
+Full guide with expected output, cleanup, and debugging: [docs/guides/zero-to-first-value.md](docs/guides/zero-to-first-value.md).
 
 ---
 

--- a/docs/guides/zero-to-first-value.md
+++ b/docs/guides/zero-to-first-value.md
@@ -1,0 +1,205 @@
+# Zero-to-First-Value: PrometheOS Lite Repo Workbench
+
+Reach a useful result in under 5 minutes.
+
+## Prerequisites
+
+- [Rust toolchain](https://rustup.rs/) (latest stable)
+- ~2 GB free disk space for the compiler
+- No API keys required
+
+## Clone and build
+
+```bash
+git clone https://github.com/prometheosai/prometheos-lite
+cd prometheos-lite
+cargo build
+```
+
+## Run against the included fixture
+
+The repository includes a small, intentionally-risky Rust project under `fixtures/repo-workbench/rust-risky/`.
+
+### 1. Create a work context
+
+```bash
+cargo run -- work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review
+```
+
+Expected output:
+
+```
+Created Repo Workbench WorkContext
+  ID: a1b2c3d4-...
+  Title: Find risky code and suggest safe improvements
+  Repo: fixtures/repo-workbench/rust-risky
+  Mode: review
+  Project type: rust
+  Candidate files: 1
+  Next: prometheos work run a1b2c3d4-...
+```
+
+For machine-readable output (useful in scripts and CI), add `--json`:
+
+```bash
+cargo run -- work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+```
+
+### 2. Run analysis
+
+Replace `<work_id>` with the ID from step 1:
+
+```bash
+cargo run -- work run <work_id>
+```
+
+Expected output:
+
+```
+Repo Workbench run complete
+  WorkContext: a1b2c3d4-...
+  Status: complete
+  Files considered: 1
+  Findings: 2
+  Risk report: .prometheos-lite/workbench/contexts/.../artifacts/risk-report-...
+  Suggested patch plan: .prometheos-lite/workbench/contexts/.../artifacts/patch-plan-...
+```
+
+### 3. List artifacts
+
+```bash
+cargo run -- work artifacts <work_id>
+```
+
+You will see two artifacts:
+
+- `risk-report-...` — a detailed risk findings report
+- `patch-plan-...` — a suggested patch plan
+
+### 4. Inspect memory
+
+```bash
+cargo run -- work memory show <work_id>
+```
+
+Shows the persisted memory blob including the goal, repo summary, and decisions made.
+
+### 5. Continue a context
+
+Continue restores context from saved memory and prints the recommended next action:
+
+```bash
+cargo run -- work continue <work_id>
+```
+
+### 6. Approve an artifact (optional)
+
+Approval records your decision in the context store. It does not modify source files.
+
+```bash
+cargo run -- work approve <artifact_id>
+```
+
+## Example end-to-end session
+
+```bash
+# Create
+cargo run -- work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review
+
+# Run (paste the work_id from above)
+cargo run -- work run a1b2c3d4-...
+
+# See what was produced
+cargo run -- work artifacts a1b2c3d4-...
+
+# Read the risk report
+cat .prometheos-lite/workbench/contexts/a1b2c3d4-.../artifacts/risk-report-*.md
+
+# Read the patch plan
+cat .prometheos-lite/workbench/contexts/a1b2c3d4-.../artifacts/patch-plan-*.md
+
+# Inspect memory
+cargo run -- work memory show a1b2c3d4-...
+
+# Continue the context
+cargo run -- work continue a1b2c3d4-...
+```
+
+## Legacy command surface
+
+The same implementation is available under the `repo` subcommand:
+
+```bash
+cargo run -- repo create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review
+```
+
+Use `repo` instead of `work` in the commands above. The output and behavior are identical.
+
+## Where artifacts are stored
+
+All Repo Workbench state is written to:
+
+```
+.prometheos-lite/workbench/
+  contexts/
+    <work_id>/
+      context.json        # WorkContext metadata and decisions
+      memory.json         # Persisted memory for continuation
+      artifacts/
+        risk-report-<id>.md
+        patch-plan-<id>.md
+```
+
+All paths are relative to the repository root passed via `--repo`.
+
+## Safety model
+
+- `work run` reads source files and writes artifacts under `.prometheos-lite/workbench/`.
+- `work approve` records approval in the context store only.
+- No repository source files are read-write accessed.
+- No automatic patch application.
+- No network access required.
+
+## Cleanup
+
+Remove all Repo Workbench state for a repository:
+
+```bash
+rm -rf fixtures/repo-workbench/rust-risky/.prometheos-lite
+```
+
+Or remove state for a specific context:
+
+```bash
+rm -rf .prometheos-lite/workbench/contexts/<work_id>
+```
+
+## You have reached first value when
+
+- [ ] A WorkContext ID was created.
+- [ ] A risk report artifact was generated.
+- [ ] A suggested patch plan artifact was generated.
+- [ ] Memory can be shown.
+- [ ] Continue restores useful context.
+- [ ] No source files were modified.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `not found: workbench context` | The work ID is invalid or the context file was deleted. Re-run `work create`. |
+| `error: invalid digit found in string` | The work ID was truncated. Copy the full UUID. |
+| Built but command not found | Run from the project root with `cargo run -- ...` or install: `cargo install --path .`. |

--- a/scripts/demo/repo-workbench-first-value.sh
+++ b/scripts/demo/repo-workbench-first-value.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIXTURE="fixtures/repo-workbench/rust-risky"
+GOAL="Find risky code and suggest safe improvements"
+
+echo "================================================"
+echo " PrometheOS Lite — Zero-to-First-Value Demo"
+echo "================================================"
+echo ""
+echo "Fixture: $FIXTURE"
+echo "Goal:    $GOAL"
+echo ""
+
+# Step 1: Create
+echo "--- Step 1: create work context ---"
+OUTPUT=$(cargo run -- work create \
+  --repo "$FIXTURE" \
+  --goal "$GOAL" \
+  --mode review \
+  --json 2>&1)
+echo "$OUTPUT"
+
+WORK_ID=$(echo "$OUTPUT" | grep '"work_id"' | sed 's/.*"work_id": "\(.*\)",/\1/')
+if [ -z "$WORK_ID" ]; then
+  echo ""
+  echo "ERROR: could not extract work_id from JSON output."
+  echo "Falling back to manual mode."
+  echo "Run the remaining commands manually with the printed work ID."
+  exit 1
+fi
+
+echo ""
+echo "Work ID: $WORK_ID"
+echo "Next: prometheos work run $WORK_ID"
+echo ""
+
+# Step 2: Run
+echo "--- Step 2: run analysis ---"
+cargo run -- work run "$WORK_ID" 2>&1
+echo ""
+echo "Next: prometheos work artifacts $WORK_ID"
+echo ""
+
+# Step 3: Artifacts
+echo "--- Step 3: list artifacts ---"
+cargo run -- work artifacts "$WORK_ID" 2>&1
+echo ""
+echo "Next: prometheos work memory show $WORK_ID"
+echo ""
+
+# Step 4: Memory
+echo "--- Step 4: inspect memory ---"
+cargo run -- work memory show "$WORK_ID" 2>&1
+echo ""
+echo "Next: prometheos work continue $WORK_ID"
+echo ""
+
+# Step 5: Continue
+echo "--- Step 5: continue context ---"
+cargo run -- work continue "$WORK_ID" 2>&1
+echo ""
+
+echo "================================================"
+echo " Zero-to-First-Value complete!"
+echo "================================================"
+echo ""
+echo "You reached first value when:"
+echo "  - A WorkContext ID was created.      ✓"
+echo "  - A risk report was generated.        ✓"
+echo "  - A patch plan was generated.         ✓"
+echo "  - Memory was shown.                   ✓"
+echo "  - Continue restored context.          ✓"
+echo "  - No source files were modified.      ✓"
+echo ""
+echo "Cleanup: rm -rf $FIXTURE/.prometheos-lite"
+echo ""

--- a/src/cli/commands/repo_workbench.rs
+++ b/src/cli/commands/repo_workbench.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use serde_json;
 use std::path::PathBuf;
 
 use prometheos_lite::repo_workbench;
@@ -30,6 +31,9 @@ enum RepoWorkbenchSubcommand {
         /// Optional title. Defaults to a short title derived from the goal.
         #[arg(long)]
         title: Option<String>,
+        /// Output JSON for machine-readable consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Run the read-only risky-code review workflow
     Run {
@@ -83,21 +87,36 @@ impl RepoWorkbenchCommand {
                 goal,
                 mode,
                 title,
+                json,
             } => {
                 let context =
                     repo_workbench::create_repo_workbench_context(&repo, &goal, &mode, title)?;
 
-                println!("Created Repo Workbench WorkContext");
-                println!("  ID: {}", context.id);
-                println!("  Title: {}", context.title);
-                println!("  Repo: {}", context.repo_path.display());
-                println!("  Mode: {}", context.mode);
-                println!("  Project type: {}", context.repo_summary.project_type);
-                println!(
-                    "  Candidate files: {}",
-                    context.repo_summary.candidate_files.len()
-                );
-                println!("  Next: prometheos repo run {}", context.id);
+                if json {
+                    let output = serde_json::json!({
+                        "work_id": context.id,
+                        "title": context.title,
+                        "repo": context.repo_path.display().to_string(),
+                        "mode": context.mode,
+                        "status": context.status,
+                        "project_type": context.repo_summary.project_type,
+                        "candidate_files": context.repo_summary.candidate_files.len(),
+                        "next": format!("prometheos repo run {}", context.id),
+                    });
+                    println!("{}", serde_json::to_string_pretty(&output)?);
+                } else {
+                    println!("Created Repo Workbench WorkContext");
+                    println!("  ID: {}", context.id);
+                    println!("  Title: {}", context.title);
+                    println!("  Repo: {}", context.repo_path.display());
+                    println!("  Mode: {}", context.mode);
+                    println!("  Project type: {}", context.repo_summary.project_type);
+                    println!(
+                        "  Candidate files: {}",
+                        context.repo_summary.candidate_files.len()
+                    );
+                    println!("  Next: prometheos repo run {}", context.id);
+                }
             }
             RepoWorkbenchSubcommand::Run { id } => {
                 let mut context = repo_workbench::load_context(&id)?;

--- a/src/cli/commands/work.rs
+++ b/src/cli/commands/work.rs
@@ -8,6 +8,7 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use serde_json;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -48,6 +49,9 @@ enum WorkSubcommand {
         /// Work mode for Repo Workbench (used with --repo)
         #[arg(long, default_value = "review")]
         mode: String,
+        /// Output JSON for machine-readable consumption
+        #[arg(long)]
+        json: bool,
     },
     /// List all WorkContexts
     List,
@@ -82,7 +86,7 @@ enum WorkSubcommand {
         #[arg(short, long)]
         max_iterations: Option<u32>,
         /// Max runtime in milliseconds
-        #[arg(short, long)]
+        #[arg(long)]
         max_runtime_ms: Option<u64>,
     },
     /// Set status of a WorkContext
@@ -228,22 +232,37 @@ impl WorkCommand {
                 goal,
                 repo,
                 mode,
+                json,
             } => {
                 if let Some(repo) = repo {
                     let context =
                         repo_workbench::create_repo_workbench_context(&repo, &goal, &mode, title)?;
 
-                    println!("Created Repo Workbench WorkContext");
-                    println!("  ID: {}", context.id);
-                    println!("  Title: {}", context.title);
-                    println!("  Repo: {}", context.repo_path.display());
-                    println!("  Mode: {}", context.mode);
-                    println!("  Project type: {}", context.repo_summary.project_type);
-                    println!(
-                        "  Candidate files: {}",
-                        context.repo_summary.candidate_files.len()
-                    );
-                    println!("  Next: prometheos work run {}", context.id);
+                    if json {
+                        let output = serde_json::json!({
+                            "work_id": context.id,
+                            "title": context.title,
+                            "repo": context.repo_path.display().to_string(),
+                            "mode": context.mode,
+                            "status": context.status,
+                            "project_type": context.repo_summary.project_type,
+                            "candidate_files": context.repo_summary.candidate_files.len(),
+                            "next": format!("prometheos work run {}", context.id),
+                        });
+                        println!("{}", serde_json::to_string_pretty(&output)?);
+                    } else {
+                        println!("Created Repo Workbench WorkContext");
+                        println!("  ID: {}", context.id);
+                        println!("  Title: {}", context.title);
+                        println!("  Repo: {}", context.repo_path.display());
+                        println!("  Mode: {}", context.mode);
+                        println!("  Project type: {}", context.repo_summary.project_type);
+                        println!(
+                            "  Candidate files: {}",
+                            context.repo_summary.candidate_files.len()
+                        );
+                        println!("  Next: prometheos work run {}", context.id);
+                    }
                     return Ok(());
                 }
 

--- a/src/repo_workbench.rs
+++ b/src/repo_workbench.rs
@@ -102,6 +102,8 @@ pub fn create_repo_workbench_context(
 
     save_context(&context)?;
     write_memory(&context, &[])?;
+    // Register in cwd-level index for cross-directory discovery
+    let _ = register_context(&id, &repo_path);
 
     Ok(context)
 }
@@ -154,47 +156,164 @@ pub fn run_repo_workbench_context(context: &mut WorkbenchContext) -> Result<()> 
     Ok(())
 }
 
+/// Look up a context file path by searching ancestors and the local registry.
+fn resolve_context_path(id: &str) -> Option<PathBuf> {
+    let filename = format!("{}.json", id);
+
+    // 1. Check registry (cwd-level index of work_id -> repo_path)
+    if let Some(path) = resolve_from_registry(id)
+        && path.exists()
+    {
+        return Some(path);
+    }
+
+    // 2. Walk parent directories for a local .prometheos-lite/workbench/contexts/
+    let cwd = std::env::current_dir().ok()?;
+    for ancestor in cwd.ancestors() {
+        let candidate = ancestor
+            .join(".prometheos-lite")
+            .join("workbench")
+            .join("contexts")
+            .join(&filename);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Read the cwd-level registry mapping work_id -> absolute repo path.
+fn resolve_from_registry(id: &str) -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let registry_path = cwd
+        .join(".prometheos-lite")
+        .join("workbench")
+        .join("registry.json");
+    let json = fs::read_to_string(registry_path).ok()?;
+    let registry: std::collections::HashMap<String, String> = serde_json::from_str(&json).ok()?;
+    let repo_path_str = registry.get(id)?;
+    let path = Path::new(repo_path_str)
+        .join(".prometheos-lite")
+        .join("workbench")
+        .join("contexts")
+        .join(format!("{}.json", id));
+    Some(path)
+}
+
+/// Record the work_id -> repo_path mapping in the cwd-level registry.
+fn register_context(id: &str, repo_path: &Path) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let registry_dir = cwd.join(".prometheos-lite").join("workbench");
+    let registry_path = registry_dir.join("registry.json");
+
+    fs::create_dir_all(&registry_dir)?;
+
+    let mut registry: std::collections::HashMap<String, String> = if registry_path.exists() {
+        let json = fs::read_to_string(&registry_path)?;
+        serde_json::from_str(&json).unwrap_or_default()
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    registry.insert(id.to_string(), repo_path.to_string_lossy().to_string());
+    fs::write(&registry_path, serde_json::to_string_pretty(&registry)?)?;
+    Ok(())
+}
+
 pub fn load_context(id: &str) -> Result<WorkbenchContext> {
-    let repo_path = normalize_repo_path(Path::new("."))?;
-    let path = contexts_dir(&repo_path).join(format!("{}.json", id));
-    let json = fs::read_to_string(&path)
-        .with_context(|| format!("WorkContext `{}` not found at {}", id, path.display()))?;
+    let path = resolve_context_path(id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "WorkContext `{}` not found. Searched registry and parent directories from {} for `.prometheos-lite/workbench/contexts/`",
+            id,
+            std::env::current_dir().unwrap_or_default().display()
+        )
+    })?;
+    let json =
+        fs::read_to_string(&path).with_context(|| format!("Failed to read {}", path.display()))?;
     let context = serde_json::from_str(&json)?;
     Ok(context)
 }
 
 pub fn find_context_by_artifact(artifact_id: &str) -> Result<WorkbenchContext> {
-    let repo_path = normalize_repo_path(Path::new("."))?;
-    let dir = contexts_dir(&repo_path);
-    for entry in fs::read_dir(&dir)
-        .with_context(|| format!("Context directory not found: {}", dir.display()))?
+    let cwd = std::env::current_dir()?;
+
+    // Search cwd-level registry first
+    let registry_path = cwd
+        .join(".prometheos-lite")
+        .join("workbench")
+        .join("registry.json");
+    if let Ok(json) = fs::read_to_string(&registry_path)
+        && let Ok(registry) =
+            serde_json::from_str::<std::collections::HashMap<String, String>>(&json)
     {
-        let entry = entry?;
-        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+        for repo_path_str in registry.values() {
+            let dir = Path::new(repo_path_str)
+                .join(".prometheos-lite")
+                .join("workbench")
+                .join("contexts");
+            if !dir.is_dir() {
+                continue;
+            }
+            if let Ok(entries) = fs::read_dir(&dir) {
+                for entry in entries.flatten() {
+                    let json = match fs::read_to_string(entry.path()) {
+                        Ok(j) => j,
+                        _ => continue,
+                    };
+                    let context: WorkbenchContext = match serde_json::from_str(&json) {
+                        Ok(c) => c,
+                        _ => continue,
+                    };
+                    if context
+                        .artifacts
+                        .iter()
+                        .any(|artifact| artifact.id == artifact_id)
+                    {
+                        return Ok(context);
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: walk parent directories for local contexts/ dirs
+    for ancestor in cwd.ancestors() {
+        let dir = ancestor
+            .join(".prometheos-lite")
+            .join("workbench")
+            .join("contexts");
+        if !dir.is_dir() {
             continue;
         }
-        let json = fs::read_to_string(entry.path())?;
-        let context: WorkbenchContext = serde_json::from_str(&json)?;
-        if context
-            .artifacts
-            .iter()
-            .any(|artifact| artifact.id == artifact_id)
-        {
-            return Ok(context);
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let json = match fs::read_to_string(entry.path()) {
+                Ok(j) => j,
+                _ => continue,
+            };
+            let context: WorkbenchContext = match serde_json::from_str(&json) {
+                Ok(c) => c,
+                _ => continue,
+            };
+            if context
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.id == artifact_id)
+            {
+                return Ok(context);
+            }
         }
     }
     anyhow::bail!(
-        "Artifact `{}` not found in current repo workbench store",
+        "Artifact `{}` not found in any repo workbench store",
         artifact_id
     )
 }
 
 pub fn repo_workbench_context_exists(id: &str) -> bool {
-    let Ok(repo_path) = normalize_repo_path(Path::new(".")) else {
-        return false;
-    };
-    let path = contexts_dir(&repo_path).join(format!("{}.json", id));
-    path.exists()
+    resolve_context_path(id).is_some()
 }
 
 pub fn get_artifacts(context: &WorkbenchContext) -> &[ArtifactRef] {


### PR DESCRIPTION
## Summary

Adds a Zero-to-First-Value path for PrometheOS Lite.

A new developer can now run the product-facing \prometheos work ...\ command path against the included fixture and reach a useful Repo Workbench result quickly.

## What changed

- Added \docs/guides/zero-to-first-value.md\.
- Added a short README quickstart section.
- Added a demo script for the Repo Workbench first-value path.
- Added \--json\ flag to \work create\ and \epo create\ for machine-readable output (used by the demo script and CI).
- Added a cwd-level registry (\.prometheos-lite/workbench/registry.json\) so contexts created with \--repo <subdir>\ are discoverable from the project root.
- Fixed a clap \-m\ short flag collision between \max_iterations\ and \max_runtime_ms\ that blocked all \work run\ commands in debug builds.
- Documented expected outputs, artifact locations, memory inspection, and cleanup.
- Preserved the read-only safety model.

## Safety model

This PR does not add automatic patch application.

\work run\ only analyzes files and writes artifacts/memory under \.prometheos-lite/workbench/\.

\work approve\ records approval only.

No fixture or repository source files are intentionally modified.

## Verification

- [x] \cargo fmt --check\
- [x] \cargo check\
- [x] \cargo test\ (all 800+ tests pass)
- [x] \cargo clippy --all-targets --all-features -- -D warnings\
- [x] Manual first-value run against \ixtures/repo-workbench/rust-risky\
- [ ] Demo script run (requires bash; Windows pending)

Notes:

- The demo script requires bash (Linux/macOS/WSL). On Windows, run the individual commands manually from the guide.
- The \--json\ flag makes the demo script fully automated (work_id extraction from JSON).
- The registry fix means contexts created from any \--repo\ path are findable from the project root.
- The clap \-m\ short flag fix was necessary to run \work run\ in debug mode (the collision was pre-existing).

## Follow-ups

- Add CI coverage for the exact first-value golden path.
- Add optional \--json\ output for all workbench commands.
- Add explicit patch application later as a separate, approval-gated command.