### PR TITLE
MVP: add installability and release prep docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ dotenv = "0.15"
 tempfile = "3"
 axum-test = "15.0"
 
+[[bin]]
+name = "prometheos"
+path = "src/main.rs"
+
 [features]
 default = []
 legacy = []  # Enable legacy agent/core modules for backward compatibility

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@
 
 PrometheOS Lite v1.2 is a Rust-based, local-first system for orchestrating AI agents through a flow-centric architecture. It provides powerful execution capabilities including parallel flows, self-reflection loops, batch processing, debugging, policy enforcement, rate limiting, and WorkContext lifecycle management.
 
+## Install locally
+
+```bash
+git clone https://github.com/prometheosai/prometheos-lite.git
+cd prometheos-lite
+cargo install --path .
+prometheos --version
+```
+
+Then run the first-value workflow against the included fixture:
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+```
+
+See [docs/guides/install.md](docs/guides/install.md) and [docs/guides/zero-to-first-value.md](docs/guides/zero-to-first-value.md).
+
 ---
 
 ## ⚡ Features

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,0 +1,104 @@
+# Installing PrometheOS Lite
+
+## Prerequisites
+
+- [Rust toolchain](https://rustup.rs/) (latest stable)
+- Cargo
+- Git
+- ~2 GB free disk space for the compiler
+- No API keys required
+
+## Install from local checkout
+
+```bash
+git clone https://github.com/prometheosai/prometheos-lite.git
+cd prometheos-lite
+cargo install --path .
+```
+
+## Verify installation
+
+```bash
+prometheos --version
+prometheos --help
+```
+
+Expected output:
+
+```
+prometheos --version
+prometheos-lite 1.6.1
+
+prometheos --help
+Usage: prometheos <COMMAND>
+...
+```
+
+## Run first-value workflow
+
+Once installed, run the Repo Workbench against the included fixture:
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+```
+
+Then follow the remaining steps in [docs/guides/zero-to-first-value.md](zero-to-first-value.md).
+
+## Troubleshooting
+
+### `prometheos: command not found`
+
+Cargo installs binaries into Cargo's bin directory. Ensure it is on your PATH:
+
+- **Linux/macOS**: `~/.cargo/bin`
+- **Windows**: `%USERPROFILE%\.cargo\bin`
+
+Add it to your PATH if needed:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"    # Linux/macOS
+```
+
+Or use the full path:
+
+```bash
+~/.cargo/bin/prometheos --version
+```
+
+### `error: failed to compile`
+
+Ensure you have the latest stable Rust toolchain:
+
+```bash
+rustup update stable
+```
+
+## Uninstall
+
+```bash
+cargo uninstall prometheos-lite
+```
+
+## Reinstall after pulling changes
+
+```bash
+git pull
+cargo install --path . --force
+```
+
+## Safety model
+
+- `work run` reads source files and writes artifacts and memory under `.prometheos-lite/workbench/`.
+- `work approve` records approval in the context store only.
+- No repository source files are modified during `work run`.
+- No automatic patch application.
+- No network access required.
+
+## Next steps
+
+- [Zero-to-First-Value guide](zero-to-first-value.md)
+- [Repo Workbench full guide](repo-workbench-mvp.md)

--- a/docs/guides/zero-to-first-value.md
+++ b/docs/guides/zero-to-first-value.md
@@ -13,8 +13,16 @@ Reach a useful result in under 5 minutes.
 ```bash
 git clone https://github.com/prometheosai/prometheos-lite
 cd prometheos-lite
+cargo install --path .
+```
+
+Or build without installing:
+
+```bash
 cargo build
 ```
+
+See [docs/guides/install.md](install.md) for full installation options.
 
 ## Run against the included fixture
 

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -1,0 +1,47 @@
+# Release Checklist
+
+## Pre-release verification
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo check`
+- [ ] `cargo test`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] Repo Workbench golden-path CI passes
+- [ ] `cargo install --path . --force`
+- [ ] `prometheos --version`
+- [ ] First-value workflow runs from installed binary against `fixtures/repo-workbench/rust-risky`
+
+## Documentation
+
+- [ ] README install section is accurate
+- [ ] `docs/guides/install.md` is accurate
+- [ ] `docs/guides/zero-to-first-value.md` is accurate
+- [ ] Safety model is documented
+
+## Safety
+
+- [ ] `work run` does not modify source files (verified by CI golden-path)
+- [ ] `work approve` records approval only
+- [ ] Local workbench state (`.prometheos-lite/`) is ignored by `.gitignore`
+
+## Versioning
+
+- [ ] Confirm `Cargo.toml` version
+- [ ] Update version if needed
+- [ ] Tag release only after CI passes
+
+## Known non-goals for first alpha
+
+- no Brain integration
+- no Mnemosyne integration
+- no cloud sync
+- no automatic patch application
+- no plugin marketplace
+- no crates.io publishing
+- no Homebrew formula
+
+## Post-release
+
+- [ ] Push git tag
+- [ ] Write release notes summarizing changes
+- [ ] Verify CI workflow runs against the tag

--- a/scripts/smoke/install-local.sh
+++ b/scripts/smoke/install-local.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== PrometheOS Lite install smoke test ==="
+echo ""
+
+echo "--- Step 1: cargo install --path . --force ---"
+cargo install --path . --force 2>&1
+echo ""
+
+echo "--- Step 2: verify binary exists and version ---"
+prometheos --version 2>&1
+echo ""
+
+echo "--- Step 3: verify help works ---"
+prometheos --help 2>&1 | head -5
+echo ""
+
+echo "--- Step 4: first-value create (JSON) ---"
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json 2>&1
+echo ""
+
+echo "=== Smoke test complete ==="
+echo ""
+echo "Note: This script installs prometheos-lite system-wide via cargo."
+echo "Run individual commands instead if you prefer not to install."


### PR DESCRIPTION
## Summary

Adds local installability and release-prep documentation for PrometheOS Lite.

This PR documents how to install the CLI locally, verify the installed binary, run the first-value workflow from the installed command, and prepare for a future alpha release.

## What changed

- Added `docs/guides/install.md`.
- Added a concise README install section.
- Added `docs/release/release-checklist.md`.
- Added `scripts/smoke/install-local.sh`.
- Added `[[bin]] name = "prometheos"` to `Cargo.toml` so the installed command is `prometheos` (instead of `prometheos-lite`).
- Linked install guide from zero-to-first-value guide.
- Updated README with install section near the top.

## Binary name

Installed command:

```
prometheos --version
prometheos-lite 1.6.1
```

The `[[bin]]` target produces the `prometheos` binary. The package name remains `prometheos-lite` (used for uninstall). `cargo run --` continues to work.

## Safety model

This PR does not add patch application. `work run` remains read-only toward repository source files. `work approve` records approval only.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo install --path . --force` (timed out on Windows; binary confirmed as `prometheos.exe` in target)
- [x] `cargo run -- --help` works
- [ ] installed binary `--version` (requires release build on Linux CI)

Notes:

- `cargo install` timed out on a Windows dev machine. All build steps pass via `cargo build`/`cargo check`/`cargo run`. Full install verification will be done on CI or a Linux host.

## Follow-ups

- Add release automation after local install flow is stable.
- Add GitHub Release binary builds later.
- Add Homebrew/crates.io packaging later only after alpha behavior is stable.
