### PR TITLE
MVP: add alpha release notes and demo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PrometheOS Lite is a local AI workbench for safe autonomous software workflows.
 
 It scans a repository, creates a WorkContext, generates review artifacts, records approval decisions, and remembers the session so work can continue later.
 
-> Alpha status: PrometheOS Lite currently focuses on the Repo Workbench golden path. It is local-first, file-backed, and intentionally conservative: it analyzes and produces artifacts, but does not apply patches automatically.
+> Alpha status: PrometheOS Lite currently focuses on the Repo Workbench golden path. It is local-first, file-backed, and intentionally conservative: it analyzes and produces artifacts, but does not apply patches automatically. For the current alpha scope, see [Alpha Notes](docs/release/alpha-notes.md).
 
 ## What works today
 

--- a/docs/demo/assets/README.md
+++ b/docs/demo/assets/README.md
@@ -1,0 +1,12 @@
+# Demo Assets
+
+This directory is reserved for future PrometheOS Lite demo screenshots and GIFs.
+
+Planned assets:
+
+- first-value terminal screenshot
+- Repo Workbench artifact screenshot
+- short demo GIF
+- README hero GIF
+
+Do not add generated binary artifacts here.

--- a/docs/demo/repo-workbench-transcript.md
+++ b/docs/demo/repo-workbench-transcript.md
@@ -1,0 +1,75 @@
+# Repo Workbench Demo Transcript
+
+This transcript shows the intended alpha demo path.
+
+## 1. Create a WorkContext
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+```
+
+Example output:
+
+```json
+{
+  "work_id": "<work_id>",
+  "repo": "fixtures/repo-workbench/rust-risky",
+  "status": "created",
+  "next": "prometheos work run <work_id>"
+}
+```
+
+## 2. Run the WorkContext
+
+```bash
+prometheos work run <work_id>
+```
+
+Expected result:
+
+- repository scanned
+- risk report generated
+- suggested patch plan generated
+- memory written
+- no source files modified
+
+## 3. Inspect artifacts
+
+```bash
+prometheos work artifacts <work_id>
+```
+
+Expected artifacts:
+
+- risk report
+- suggested patch plan
+
+## 4. Show memory
+
+```bash
+prometheos work memory show <work_id>
+```
+
+Expected result:
+
+- WorkContext summary
+- goal
+- repo path
+- status
+- artifact references
+- next action
+
+## 5. Continue
+
+```bash
+prometheos work continue <work_id>
+```
+
+Expected result:
+
+- previous context restored
+- next action displayed

--- a/docs/guides/zero-to-first-value.md
+++ b/docs/guides/zero-to-first-value.md
@@ -173,6 +173,8 @@ All Repo Workbench state is written to:
 
 All paths are relative to the repository root passed via `--repo`.
 
+For the current alpha scope and safety model overview, see [Alpha Notes](../release/alpha-notes.md). For a demo transcript, see [Repo Workbench Demo](../demo/repo-workbench-transcript.md).
+
 ## Safety model
 
 - `work run` reads source files and writes artifacts under `.prometheos-lite/workbench/`.

--- a/docs/release/alpha-notes.md
+++ b/docs/release/alpha-notes.md
@@ -1,0 +1,95 @@
+# PrometheOS Lite Alpha Notes
+
+PrometheOS Lite is currently in alpha.
+
+This alpha focuses on one useful local workflow: running the Repo Workbench against a repository, generating review artifacts, recording approval decisions, and preserving memory so work can continue later.
+
+## What is included
+
+- Local `prometheos` CLI install path.
+- Product-facing `prometheos work ...` command surface.
+- Repo Workbench MVP.
+- File-backed WorkContext storage.
+- Repository scanning.
+- Risk pattern detection.
+- Risk report artifact.
+- Suggested patch plan artifact.
+- Approval recording.
+- WorkContext memory.
+- Continuation.
+- Zero-to-First-Value guide.
+- Demo script.
+- CI golden-path coverage.
+- Install guide.
+- Release checklist.
+
+## Demo workflow
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+
+prometheos work run <work_id>
+prometheos work artifacts <work_id>
+prometheos work memory show <work_id>
+prometheos work continue <work_id>
+```
+
+## What the demo proves
+
+- A WorkContext can be created from a local repository.
+- The repository can be scanned.
+- Risk-review artifacts can be generated.
+- Memory can be stored and shown.
+- A WorkContext can be continued.
+- The workflow does not modify fixture source files.
+
+## Safety model
+
+- `work run` reads source files and writes artifacts/memory under `.prometheos-lite/workbench/`.
+- `work approve` records approval only.
+- No automatic patch application.
+- No source file mutation during analysis.
+- The golden-path CI verifies fixture source files are not modified.
+
+## What is not included yet
+
+- Automatic patch application.
+- Full autonomous coding.
+- Cloud control plane.
+- Team workspace.
+- Plugin marketplace.
+- Mnemosyne integration.
+- Brain integration.
+- Voice/UI layer.
+- SATI/trading workflows.
+
+## Recommended first test
+
+Use the included fixture:
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+```
+
+Then follow:
+
+- [Install guide](../guides/install.md)
+- [Zero-to-First-Value guide](../guides/zero-to-first-value.md)
+- [Repo Workbench guide](../guides/repo-workbench-mvp.md)
+
+## Next milestones
+
+- Add demo screenshots or GIF.
+- Verify install smoke test on Linux CI.
+- Add alpha release tag.
+- Add GitHub Release notes.
+- Add optional JSON output for remaining workbench commands.
+- Add explicit approval-gated patch application later.

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -17,6 +17,9 @@
 - [ ] `docs/guides/install.md` is accurate
 - [ ] `docs/guides/zero-to-first-value.md` is accurate
 - [ ] Safety model is documented
+- [ ] `docs/release/alpha-notes.md` is accurate
+- [ ] demo transcript is accurate
+- [ ] README links to alpha notes
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Adds alpha release notes and demo materials for PrometheOS Lite.

This PR documents the current alpha scope, the Repo Workbench demo path, the safety model, what is intentionally not included yet, and where future demo assets will live.

## What changed

- Added \docs/release/alpha-notes.md\.
- Added \docs/demo/repo-workbench-transcript.md\.
- Added \docs/demo/assets/README.md\.
- Added \docs/demo/assets/.gitkeep\.
- Linked alpha notes from README and supporting docs.
- Updated release checklist with alpha/demo documentation items.

## Safety model

Documentation-only PR.

No patch application added.

No source-modifying behavior changed.

## Verification

- [x] \cargo fmt --check\
- [x] \cargo check\
- [x] \cargo test\
- [x] \cargo clippy --all-targets --all-features -- -D warnings\
- [x] Documentation links checked manually

Notes:

No code changes were introduced. All 693 tests passed (2 ignored, pre-existing). Cargo fmt, check, and clippy all pass cleanly.

## Follow-ups

- Add actual screenshot/GIF assets after the demo flow is recorded.
- Add alpha release tag and GitHub Release notes.
- Add release automation after manual alpha release flow is stable.