### PR TITLE
MVP: document local model compatibility path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ prometheos work
 
 Future layers such as Mnemosyne and Brain should plug into this axis rather than creating separate user-facing universes.
 
+PrometheOS Lite is model-agnostic by design. Future local model support should allow coding models served through runtimes such as Ollama to plug into the `prometheos work` axis without changing the safety model. See [Local Model Compatibility](docs/guides/local-model-compatibility.md).
+
 ---
 
 ## Architecture
@@ -184,4 +186,5 @@ Project documentation is organized under `/docs`:
 - `docs/prd` - Product requirements and roadmap docs
 - `docs/operations` - Project operations and management setup
 - `docs/guides` - Contributor and usage guides
+- `docs/research` - Research notes and compatibility analysis
 - `docs/architecture` - Technical design references

--- a/docs/guides/local-model-compatibility.md
+++ b/docs/guides/local-model-compatibility.md
@@ -1,0 +1,87 @@
+# Local Model Compatibility
+
+PrometheOS Lite is designed to be a local-first workbench for safe autonomous software workflows.
+
+The model is not the product boundary. The workflow is.
+
+PrometheOS Lite should be able to wrap coding models through:
+
+- repository context
+- WorkContexts
+- artifacts
+- approval gates
+- memory
+- continuation
+- trace collection
+
+## Why local coding models matter
+
+Local coding models are improving quickly. They make it possible to run more developer workflows locally, reduce dependence on remote providers, and experiment with repo-aware automation in a safer environment.
+
+## Ollama and Ornith
+
+Ollama provides a local model runtime.
+
+Ornith is an example of a local/open coding-model family that can be served through Ollama.
+
+Example Ollama command:
+
+```bash
+ollama run ornith
+```
+
+PrometheOS Lite does not currently invoke Ornith directly. The Repo Workbench MVP is deterministic and does not require a model to reach first value.
+
+## Current PrometheOS Lite state
+
+The current Repo Workbench MVP does not require a model to reach first value. It scans repositories, detects risk patterns, generates artifacts, records approval decisions, and writes memory locally.
+
+PrometheOS Lite already supports OpenAI-compatible endpoints through provider configuration, including local providers such as LM Studio and Ollama. These are available for flows that invoke a model, but the golden path does not depend on them.
+
+## Target compatibility path
+
+Future local model compatibility should look like:
+
+```text
+prometheos work
+  -> WorkContext
+  -> repo scan
+  -> model provider
+  -> artifact generation
+  -> approval gate
+  -> memory
+  -> continuation
+```
+
+## Future provider goals
+
+PrometheOS Lite should eventually support:
+
+- local deterministic analysis
+- Ollama-compatible local models
+- OpenAI-compatible local endpoints
+- hosted model providers
+- explicit model selection per WorkContext
+- provider metadata in artifacts and memory
+
+## Safety model
+
+Local model support must preserve the current safety model:
+
+- no automatic source modification during analysis
+- no automatic patch application
+- approval records decisions only
+- artifacts are reviewable before any future apply step
+- source mutation must remain behind an explicit approval-gated command
+
+## Non-goals for alpha
+
+The alpha does not yet promise:
+
+- automatic coding
+- autonomous patch application
+- benchmark-level performance claims
+- Brain learning integration
+- Mnemosyne memory backend
+- cloud orchestration
+- model training

--- a/docs/release/alpha-notes.md
+++ b/docs/release/alpha-notes.md
@@ -85,6 +85,14 @@ Then follow:
 - [Zero-to-First-Value guide](../guides/zero-to-first-value.md)
 - [Repo Workbench guide](../guides/repo-workbench-mvp.md)
 
+## Model compatibility direction
+
+The alpha workflow does not depend on a specific coding model.
+
+PrometheOS Lite is intended to remain model-agnostic: local and hosted models should eventually plug into the WorkContext workflow while preserving reviewable artifacts, approval gates, memory, and continuation.
+
+See [Local Model Compatibility](../guides/local-model-compatibility.md).
+
 ## Next milestones
 
 - Add demo screenshots or GIF.

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -21,6 +21,8 @@
 - [ ] `docs/release/alpha-notes.md` is accurate
 - [ ] demo transcript is accurate
 - [ ] README links to alpha notes
+- [ ] Local model compatibility docs are accurate
+- [ ] No unsupported model integration is claimed
 
 ## Safety
 

--- a/docs/research/ornith-compatibility-note.md
+++ b/docs/research/ornith-compatibility-note.md
@@ -1,0 +1,38 @@
+# Ornith Compatibility Note
+
+## Summary
+
+Ornith is a local/open coding-model family that makes local model compatibility more strategically important for PrometheOS Lite.
+
+PrometheOS Lite should treat models like Ornith as interchangeable reasoning engines that can plug into the WorkContext workflow over time.
+
+## Strategic implication
+
+The model layer is moving quickly.
+
+PrometheOS Lite should focus on:
+
+- workflow orchestration
+- repository context
+- approval boundaries
+- artifact generation
+- memory
+- continuation
+- provider abstraction
+- trace collection for future Brain learning
+
+## What this does not mean
+
+This does not mean PrometheOS Lite should become a model lab.
+
+This does not mean Brain should immediately compete with Ornith as a coding model.
+
+This does not mean the product should expand scope before alpha.
+
+## Recommended response
+
+- Ship Lite alpha.
+- Document local model compatibility.
+- Audit model-provider architecture.
+- Add provider abstraction only after the alpha path remains stable.
+- Use WorkContext traces as the eventual Brain substrate.


### PR DESCRIPTION
## Summary

Adds local model compatibility documentation for PrometheOS Lite.

This PR explains how local coding models, including Ollama-hosted models such as Ornith, fit into the PrometheOS Lite roadmap without expanding alpha scope or claiming unsupported integration.

## What changed

- Added \docs/guides/local-model-compatibility.md\.
- Added \docs/research/ornith-compatibility-note.md\.
- Updated README with a concise model-agnostic direction note.
- Updated alpha notes with local model compatibility direction.
- Updated release checklist with model compatibility documentation checks.

## Safety model

Documentation-only PR.

No model integration added.

No patch application added.

No source-modifying behavior changed.

The documented direction preserves the current safety model: reviewable artifacts, approval gates, memory, and no automatic source modification.

## Verification

- [x] \cargo fmt --check\
- [x] \cargo check\
- [x] \cargo test\
- [x] \cargo clippy --all-targets --all-features -- -D warnings\
- [x] Documentation links checked manually

Notes:

No code changes introduced. All verification checks pass cleanly.

## Follow-ups

- Audit existing model-provider architecture.
- Add provider configuration docs if current code supports it.
- Add Ollama/OpenAI-compatible provider integration only after alpha docs remain stable.
- Add model metadata to WorkContext artifacts later.