### PR TITLE
MVP: add artifact provenance metadata

### DIFF
--- a/docs/guides/local-model-compatibility.md
+++ b/docs/guides/local-model-compatibility.md
@@ -38,6 +38,8 @@ The current Repo Workbench MVP does not require a model to reach first value. It
 
 PrometheOS Lite already supports OpenAI-compatible endpoints through provider configuration, including local providers such as LM Studio and Ollama. These are available for flows that invoke a model, but the golden path does not depend on them.
 
+Repo Workbench artifacts include provenance metadata. In the current alpha path, artifacts are produced by deterministic static analysis and do not invoke a model.
+
 ## Target compatibility path
 
 Future local model compatibility should look like:

--- a/docs/guides/repo-workbench-mvp.md
+++ b/docs/guides/repo-workbench-mvp.md
@@ -102,6 +102,17 @@ The MVP never writes changes into the target repository source files.
 
 This keeps the first shipped loop safe while proving the product shape.
 
+## Artifact Provenance
+
+Repo Workbench artifacts include provenance metadata that records how each artifact was produced:
+
+- **Generator:** `repo_workbench`
+- **Generation mode:** `deterministic_static_analysis`
+- **Model invoked:** `false`
+- **Provider/model fields:** `null` (no model was used)
+
+In the current alpha path, all artifacts are produced by deterministic static analysis. Provenance metadata is included in both the structured `ArtifactRef` records and the rendered markdown output on disk.
+
 ## Current Risk Heuristics
 
 The first scanner checks common risky patterns, including:

--- a/docs/research/provider-architecture-audit.md
+++ b/docs/research/provider-architecture-audit.md
@@ -120,16 +120,10 @@ PrometheOS Lite has a complete multi-provider LLM abstraction layer that is not 
 
 ## Recommendation
 
-The next PR should be a **provider configuration guide** (`docs/guides/provider-configuration.md`) that documents:
+The next PRs after this audit should be:
 
-- How to configure OpenRouter (current default)
-- How to configure Ollama (including Ornith)
-- How to configure LM Studio
-- How to configure OpenAI-compatible endpoints
-- Environment variables reference
-- Config file reference
-- How the provider selection and failover work
-
-This requires no code changes. It closes the documentation gap for local model support while the alpha golden path remains deterministic, model-agnostic, and safe.
+1. **Provider configuration guide** (`docs/guides/provider-configuration.md`) — documents how to configure all provider types. No code changes. (Completed: PR #44)
+2. **Provider config validation tests** — tests that provider config parsing and routing behavior work as documented. No network calls. (Completed: PR #45)
+3. **Artifact provenance metadata** — add explicit provenance/metadata to Repo Workbench artifacts showing whether a model was invoked. (Completed: PR #46)
 
 After the docs PR, a follow-up could add optional `--model` / `--provider` flags to `prometheos work run` for model-augmented analysis, but only after the alpha release is stable and the deterministic path is proven.

--- a/src/repo_workbench.rs
+++ b/src/repo_workbench.rs
@@ -41,6 +41,37 @@ pub struct FileSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactProvenance {
+    pub generator: String,
+    pub generation_mode: String,
+    pub model_invoked: bool,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub provider_kind: Option<String>,
+    pub local_provider: Option<bool>,
+    pub work_id: String,
+    pub artifact_type: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ArtifactProvenance {
+    pub fn deterministic(work_id: &str, artifact_type: &str) -> Self {
+        Self {
+            generator: "repo_workbench".to_string(),
+            generation_mode: "deterministic_static_analysis".to_string(),
+            model_invoked: false,
+            provider: None,
+            model: None,
+            provider_kind: None,
+            local_provider: None,
+            work_id: work_id.to_string(),
+            artifact_type: artifact_type.to_string(),
+            created_at: Utc::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArtifactRef {
     pub id: String,
     pub kind: String,
@@ -49,6 +80,7 @@ pub struct ArtifactRef {
     pub status: String,
     pub requires_approval: bool,
     pub created_at: DateTime<Utc>,
+    pub provenance: ArtifactProvenance,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -635,6 +667,12 @@ fn looks_like_hardcoded_secret(lower: &str) -> bool {
 fn render_risk_report(context: &WorkbenchContext, findings: &[RiskFinding]) -> String {
     let mut out = String::new();
     out.push_str("# Risk Review\n\n");
+    out.push_str("## Provenance\n\n");
+    out.push_str("- Generator: Repo Workbench\n");
+    out.push_str("- Generation mode: deterministic static analysis\n");
+    out.push_str("- Model invoked: no\n");
+    out.push_str("- Provider: none\n");
+    out.push_str("- Model: none\n\n");
     out.push_str("## Summary\n\n");
     out.push_str(&format!(
         "PrometheOS Lite reviewed `{}` and found {} risk finding(s) across {} candidate file(s).\n\n",
@@ -673,6 +711,12 @@ fn render_patch_suggestions(context: &WorkbenchContext, findings: &[RiskFinding]
     let mut out = String::new();
     out.push_str("# Suggested Patch Plan\n\n");
     out.push_str("> Safety note: this MVP artifact is a staged suggestion only. No repository files were modified.\n\n");
+    out.push_str("## Provenance\n\n");
+    out.push_str("- Generator: Repo Workbench\n");
+    out.push_str("- Generation mode: deterministic static analysis\n");
+    out.push_str("- Model invoked: no\n");
+    out.push_str("- Provider: none\n");
+    out.push_str("- Model: none\n\n");
     out.push_str(&format!("WorkContext: `{}`\n\n", context.id));
 
     if findings.is_empty() {
@@ -712,6 +756,7 @@ fn write_artifact(
     let filename = format!("{}-{}.md", kind, &id[..8]);
     let path = dir.join(filename);
     fs::write(&path, content)?;
+    let now = Utc::now();
     Ok(ArtifactRef {
         id,
         kind: kind.to_string(),
@@ -719,7 +764,19 @@ fn write_artifact(
         path,
         status: status.to_string(),
         requires_approval,
-        created_at: Utc::now(),
+        created_at: now,
+        provenance: ArtifactProvenance {
+            generator: "repo_workbench".to_string(),
+            generation_mode: "deterministic_static_analysis".to_string(),
+            model_invoked: false,
+            provider: None,
+            model: None,
+            provider_kind: None,
+            local_provider: None,
+            work_id: context.id.clone(),
+            artifact_type: kind.to_string(),
+            created_at: now,
+        },
     })
 }
 
@@ -819,6 +876,38 @@ mod tests {
             artifacts: Vec::new(),
             decisions: Vec::new(),
             next_action: None,
+        }
+    }
+
+    fn make_artifact_ref(
+        id: &str,
+        kind: &str,
+        title: &str,
+        path: &str,
+        status: &str,
+        requires_approval: bool,
+    ) -> ArtifactRef {
+        let now = Utc::now();
+        ArtifactRef {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            title: title.to_string(),
+            path: PathBuf::from(path),
+            status: status.to_string(),
+            requires_approval,
+            created_at: now,
+            provenance: ArtifactProvenance {
+                generator: "repo_workbench".to_string(),
+                generation_mode: "deterministic_static_analysis".to_string(),
+                model_invoked: false,
+                provider: None,
+                model: None,
+                provider_kind: None,
+                local_provider: None,
+                work_id: "test-id".to_string(),
+                artifact_type: kind.to_string(),
+                created_at: now,
+            },
         }
     }
 
@@ -1132,6 +1221,18 @@ mod tests {
         }];
         let report = render_risk_report(&context, &findings);
         assert!(report.contains("# Risk Review"), "should have title");
+        assert!(
+            report.contains("## Provenance"),
+            "should have provenance section"
+        );
+        assert!(
+            report.contains("Model invoked: no"),
+            "should state no model"
+        );
+        assert!(
+            report.contains("deterministic"),
+            "should reference deterministic analysis"
+        );
         assert!(report.contains("F-001"), "should contain finding ID");
         assert!(report.contains("Potential panic"), "should contain summary");
     }
@@ -1167,6 +1268,11 @@ mod tests {
             patch.contains("# Suggested Patch Plan"),
             "should have title"
         );
+        assert!(
+            patch.contains("## Provenance"),
+            "should have provenance section"
+        );
+        assert!(patch.contains("Model invoked: no"), "should state no model");
         assert!(patch.contains("F-001"), "should contain finding ID");
         assert!(patch.contains("Approval"), "should mention approval");
     }
@@ -1224,24 +1330,8 @@ mod tests {
     #[test]
     fn test_upsert_artifact_replaces_by_kind() {
         let mut context = make_context(Path::new("/tmp"));
-        let a1 = ArtifactRef {
-            id: "id-1".to_string(),
-            kind: "risk-report".to_string(),
-            title: "Old".to_string(),
-            path: PathBuf::from("/tmp/a.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        };
-        let a2 = ArtifactRef {
-            id: "id-2".to_string(),
-            kind: "risk-report".to_string(),
-            title: "New".to_string(),
-            path: PathBuf::from("/tmp/b.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        };
+        let a1 = make_artifact_ref("id-1", "risk-report", "Old", "/tmp/a.md", "ready", false);
+        let a2 = make_artifact_ref("id-2", "risk-report", "New", "/tmp/b.md", "ready", false);
         context.artifacts.push(a1);
         upsert_artifact(&mut context, a2);
         assert_eq!(
@@ -1258,24 +1348,15 @@ mod tests {
     #[test]
     fn test_upsert_artifact_appends_different_kind() {
         let mut context = make_context(Path::new("/tmp"));
-        let a1 = ArtifactRef {
-            id: "id-1".to_string(),
-            kind: "risk-report".to_string(),
-            title: "Report".to_string(),
-            path: PathBuf::from("/tmp/a.md"),
-            status: "ready".to_string(),
-            requires_approval: false,
-            created_at: Utc::now(),
-        };
-        let a2 = ArtifactRef {
-            id: "id-2".to_string(),
-            kind: "suggested-patch".to_string(),
-            title: "Patch".to_string(),
-            path: PathBuf::from("/tmp/b.md"),
-            status: "awaiting_approval".to_string(),
-            requires_approval: true,
-            created_at: Utc::now(),
-        };
+        let a1 = make_artifact_ref("id-1", "risk-report", "Report", "/tmp/a.md", "ready", false);
+        let a2 = make_artifact_ref(
+            "id-2",
+            "suggested-patch",
+            "Patch",
+            "/tmp/b.md",
+            "awaiting_approval",
+            true,
+        );
         context.artifacts.push(a1);
         upsert_artifact(&mut context, a2);
         assert_eq!(
@@ -1295,6 +1376,7 @@ mod tests {
         context.goal = "Find issues".to_string();
         context.status = "awaiting_approval".to_string();
         context.next_action = Some("Approve the patch".to_string());
+        let now = Utc::now();
         context.artifacts.push(ArtifactRef {
             id: "art-1".to_string(),
             kind: "risk-report".to_string(),
@@ -1302,7 +1384,19 @@ mod tests {
             path: PathBuf::from("report.md"),
             status: "ready".to_string(),
             requires_approval: false,
-            created_at: Utc::now(),
+            created_at: now,
+            provenance: ArtifactProvenance {
+                generator: "repo_workbench".to_string(),
+                generation_mode: "deterministic_static_analysis".to_string(),
+                model_invoked: false,
+                provider: None,
+                model: None,
+                provider_kind: None,
+                local_provider: None,
+                work_id: "mem-test-id".to_string(),
+                artifact_type: "risk-report".to_string(),
+                created_at: now,
+            },
         });
 
         write_memory(&context, &[]).unwrap();
@@ -1360,6 +1454,7 @@ mod tests {
         let dir = temp_repo();
         let mut context = make_context(dir.path());
         let artifact_id = "approve-test-id".to_string();
+        let now = Utc::now();
         context.artifacts.push(ArtifactRef {
             id: artifact_id.clone(),
             kind: "suggested-patch".to_string(),
@@ -1367,7 +1462,19 @@ mod tests {
             path: PathBuf::from("patch.md"),
             status: "awaiting_approval".to_string(),
             requires_approval: true,
-            created_at: Utc::now(),
+            created_at: now,
+            provenance: ArtifactProvenance {
+                generator: "repo_workbench".to_string(),
+                generation_mode: "deterministic_static_analysis".to_string(),
+                model_invoked: false,
+                provider: None,
+                model: None,
+                provider_kind: None,
+                local_provider: None,
+                work_id: "test-id".to_string(),
+                artifact_type: "suggested-patch".to_string(),
+                created_at: now,
+            },
         });
 
         let artifact = context
@@ -1479,5 +1586,76 @@ mod tests {
             memory_dir(p),
             Path::new("/repo/.prometheos-lite/workbench/memory")
         );
+    }
+
+    // ── provenance ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_write_artifact_includes_provenance() {
+        let dir = temp_repo();
+        let context = make_context(dir.path());
+        let artifact = write_artifact(
+            &context,
+            "risk-report",
+            "Test Report",
+            "ready",
+            false,
+            "# Report",
+        )
+        .unwrap();
+        assert_eq!(artifact.provenance.generator, "repo_workbench");
+        assert_eq!(
+            artifact.provenance.generation_mode,
+            "deterministic_static_analysis"
+        );
+        assert!(!artifact.provenance.model_invoked);
+        assert!(artifact.provenance.provider.is_none());
+        assert!(artifact.provenance.model.is_none());
+        assert_eq!(artifact.provenance.work_id, "test-id");
+        assert_eq!(artifact.provenance.artifact_type, "risk-report");
+    }
+
+    #[test]
+    fn test_artifact_provenance_deterministic_constructor() {
+        let provenance = ArtifactProvenance::deterministic("test-work", "risk-report");
+        assert_eq!(provenance.generator, "repo_workbench");
+        assert!(!provenance.model_invoked);
+        assert!(provenance.provider.is_none());
+        assert!(provenance.model.is_none());
+        assert_eq!(provenance.work_id, "test-work");
+        assert_eq!(provenance.artifact_type, "risk-report");
+    }
+
+    #[test]
+    fn test_provenance_is_serialized_in_artifact_ref() {
+        let now = Utc::now();
+        let artifact = ArtifactRef {
+            id: "test-id".to_string(),
+            kind: "risk-report".to_string(),
+            title: "Test".to_string(),
+            path: PathBuf::from("/tmp/test.md"),
+            status: "ready".to_string(),
+            requires_approval: false,
+            created_at: now,
+            provenance: ArtifactProvenance {
+                generator: "repo_workbench".to_string(),
+                generation_mode: "deterministic_static_analysis".to_string(),
+                model_invoked: false,
+                provider: None,
+                model: None,
+                provider_kind: None,
+                local_provider: None,
+                work_id: "wid".to_string(),
+                artifact_type: "risk-report".to_string(),
+                created_at: now,
+            },
+        };
+        let json = serde_json::to_string(&artifact).unwrap();
+        assert!(json.contains("provenance"));
+        assert!(json.contains("deterministic_static_analysis"));
+        assert!(json.contains("\"model_invoked\":false"));
+        let deserialized: ArtifactRef = serde_json::from_str(&json).unwrap();
+        assert!(!deserialized.provenance.model_invoked);
+        assert!(deserialized.provenance.provider.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Adds provenance metadata to Repo Workbench artifacts.

This PR makes artifacts self-describing by recording whether they were generated by deterministic Repo Workbench analysis or by a model-backed flow. In the current alpha path, artifacts explicitly record that no model was invoked.

## What changed

**New types (src/repo_workbench.rs):**
- `ArtifactProvenance` struct with fields: `generator`, `generation_mode`, `model_invoked`, `provider`, `model`, `provider_kind`, `local_provider`, `work_id`, `artifact_type`, `created_at`
- `ArtifactProvenance::deterministic()` constructor for the current golden path

**ArtifactRef now includes provenance:**
- `provenance: ArtifactProvenance` field added to `ArtifactRef`
- `write_artifact()` populates provenance automatically

**Markdown artifacts now include provenance section:**
- Risk Review Report includes `## Provenance` section
- Suggested Patch Plan includes `## Provenance` section
- Both state: Generator = Repo Workbench, Generation mode = deterministic static analysis, Model invoked = no

**Tests added:**
- `test_write_artifact_includes_provenance` — verifies provenance on written artifacts
- `test_artifact_provenance_deterministic_constructor` — verifies deterministic() helper
- `test_provenance_is_serialized_in_artifact_ref` — verifies JSON serialization round-trip
- Existing render tests updated to check for provenance section in markdown

**Docs updated:**
- `docs/guides/repo-workbench-mvp.md` — added Artifact Provenance section
- `docs/guides/local-model-compatibility.md` — added provenance note
- `docs/research/provider-architecture-audit.md` — updated recommendation to reflect completed PRs

## Safety model

No model invocation added.

No provider integration added.

No network calls added.

No patch application added.

No source-modifying behavior changed.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test` (555 pass, including 3 new provenance tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build`

Notes:

Provenance metadata is added to both structured ArtifactRef records (serialized as JSON in WorkbenchContext) and rendered markdown output on disk. For the current deterministic golden path, all provider/model fields are null/false.

## Follow-ups

- Add provider/model metadata to model-backed flows once models are invoked.
- Add mock HTTP provider smoke tests.
- Add explicit Ollama/Ornith manual compatibility validation.
