### PR TITLE
MVP: add Ollama and Ornith compatibility guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See:
 - [Install guide](docs/guides/install.md)
 - [Zero-to-first-value guide](docs/guides/zero-to-first-value.md)
 - [Repo Workbench MVP guide](docs/guides/repo-workbench-mvp.md)
+- [Ollama and Ornith compatibility guide](docs/guides/ollama-ornith-compatibility.md)
 
 ## Safety model
 

--- a/docs/guides/local-model-compatibility.md
+++ b/docs/guides/local-model-compatibility.md
@@ -87,3 +87,5 @@ The alpha does not yet promise:
 - Mnemosyne memory backend
 - cloud orchestration
 - model training
+
+See also the [Ollama and Ornith compatibility guide](ollama-ornith-compatibility.md) for step-by-step local model setup and validation.

--- a/docs/guides/ollama-ornith-compatibility.md
+++ b/docs/guides/ollama-ornith-compatibility.md
@@ -1,0 +1,106 @@
+# Ollama and Ornith Compatibility
+
+PrometheOS Lite is model-agnostic by design.
+
+The current Repo Workbench golden path does not require a model. It performs deterministic static analysis and writes reviewable artifacts locally.
+
+Provider-backed flows can use the existing OpenAI-compatible provider path where supported.
+
+## What is supported today
+
+- Provider configuration can describe Ollama, LM Studio, OpenRouter, OpenAI-compatible endpoints, and generic providers.
+- Provider configuration parsing is covered by tests.
+- OpenAI-compatible request/response behavior is covered by mock provider tests.
+- Repo Workbench artifacts include provenance metadata.
+- The deterministic Repo Workbench path explicitly records that no model was invoked.
+
+## What is not claimed yet
+
+- No automatic Ornith integration is claimed.
+- No benchmark claims are made.
+- No model download is performed by PrometheOS Lite.
+- No normal CI test requires Ollama or Ornith.
+- No source patching is performed automatically.
+- No provider-backed Repo Workbench generation is claimed unless implemented separately.
+
+## Ollama setup
+
+Install Ollama using its official instructions.
+
+Then run:
+
+```bash
+ollama pull llama3.2
+ollama run llama3.2
+```
+
+For Ornith, use the model name available in the local Ollama registry. Example:
+
+```bash
+ollama run ornith
+```
+
+Only use the exact model name available locally.
+
+## PrometheOS provider config example
+
+Use a provider entry like:
+
+```json
+{
+  "name": "ollama_local",
+  "provider_type": "ollama",
+  "enabled": true,
+  "base_url": "http://localhost:11434",
+  "model": "ornith",
+  "api_key_env": null
+}
+```
+
+Note:
+
+PrometheOS Lite appends `/v1/chat/completions` through the OpenAI-compatible client path. Configure `base_url` as `http://localhost:11434`, not `http://localhost:11434/v1/chat/completions`.
+
+## Local-first mode chain
+
+```json
+{
+  "mode_chains": {
+    "fast": ["ollama_local"],
+    "balanced": ["ollama_local", "openrouter_balanced"],
+    "deep": ["ollama_local", "openrouter_deep"],
+    "coding": ["ollama_local", "openrouter_coding"]
+  }
+}
+```
+
+## Provenance
+
+When model-backed flows are used in the future, artifacts should record provider and model metadata.
+
+Current deterministic Repo Workbench artifacts record:
+
+- model invoked: no
+- provider: none
+- model: none
+
+## Manual local endpoint smoke test
+
+This test is ignored by default and never runs in normal CI.
+
+Example:
+
+```bash
+PROMETHEOS_TEST_LOCAL_BASE_URL=http://localhost:11434 \
+PROMETHEOS_TEST_LOCAL_MODEL=ornith \
+cargo test local_openai_compatible_endpoint -- --ignored
+```
+
+## Manual validation checklist
+
+- [ ] Ollama installed locally
+- [ ] desired model pulled locally
+- [ ] local endpoint reachable
+- [ ] provider config points to `http://localhost:11434`
+- [ ] flow using provider path succeeds
+- [ ] generated artifact provenance is accurate, if artifacts are generated

--- a/docs/guides/provider-configuration.md
+++ b/docs/guides/provider-configuration.md
@@ -201,7 +201,7 @@ This guide documents provider configuration paths available through the existing
 
 The Repo Workbench golden path does not invoke a model today.
 
-Provider configuration applies to flows that explicitly call LLM providers. Future work should add provider smoke tests, model metadata in WorkContexts/artifacts, and explicit Ollama/Ornith compatibility validation.
+Provider configuration applies to flows that explicitly call LLM providers. See also the [Ollama and Ornith compatibility guide](ollama-ornith-compatibility.md) for local model setup.
 
 ## Notes
 


### PR DESCRIPTION
## Goal

Add a clear manual compatibility guide for using PrometheOS Lite with local OpenAI-compatible providers, especially Ollama and Ornith, without claiming automatic or fully tested integration beyond what the code and tests prove.

## What's included

- New guide at \docs/guides/ollama-ornith-compatibility.md\
- Links from:
  - \docs/guides/provider-configuration.md\
  - \docs/guides/local-model-compatibility.md\
  - \README.md\

### Guide covers

- What is supported today vs what is not claimed
- Ollama setup instructions
- PrometheOS provider config example
- Local-first mode chain configuration
- Provenance documentation
- Manual validation checklist
- Placeholder for manual local endpoint smoke test (\-- --ignored\)

No real provider calls, no model downloads, no CI impact.