### PR TITLE
MVP: add manual local endpoint integration test

### DIFF
--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -11,6 +11,7 @@
 - [ ] `prometheos --version`
 - [ ] First-value workflow runs from installed binary against `fixtures/repo-workbench/rust-risky`
 - [ ] Linux install smoke CI passes
+- [ ] Optional manual local endpoint smoke test run
 
 ## Documentation
 

--- a/src/llm/client/integration_tests.rs
+++ b/src/llm/client/integration_tests.rs
@@ -1,0 +1,57 @@
+//! Manual local endpoint integration test.
+//!
+//! This test is ignored by default and never runs in normal CI.
+//! It validates that a real local OpenAI-compatible endpoint (such as
+//! Ollama or LM Studio) can receive a chat completion request and
+//! return a non-empty response.
+//!
+//! ## Running manually
+//!
+//! ```bash
+//! PROMETHEOS_TEST_LOCAL_BASE_URL=http://localhost:11434 \
+//! PROMETHEOS_TEST_LOCAL_MODEL=ornith \
+//! cargo test local_openai_compatible_endpoint -- --ignored
+//! ```
+//!
+//! If the env vars are not set the test will fail with a clear message.
+
+use crate::llm::client::LlmClient;
+
+#[tokio::test]
+#[ignore]
+async fn local_openai_compatible_endpoint_smoke_test() {
+    let base_url = std::env::var("PROMETHEOS_TEST_LOCAL_BASE_URL")
+        .expect("PROMETHEOS_TEST_LOCAL_BASE_URL must be set (e.g. http://localhost:11434)");
+
+    let model = std::env::var("PROMETHEOS_TEST_LOCAL_MODEL")
+        .expect("PROMETHEOS_TEST_LOCAL_MODEL must be set (e.g. ornith or llama3.2)");
+
+    let client = LlmClient::new(&base_url, &model)
+        .expect("should build LlmClient")
+        .with_retries(1);
+
+    let result = client
+        .generate("Say hello in exactly one short sentence.")
+        .await;
+
+    match result {
+        Ok(text) => {
+            assert!(
+                !text.is_empty(),
+                "model returned an empty response"
+            );
+            eprintln!("[integration] local endpoint smoke test passed — response length: {}", text.len());
+        }
+        Err(e) => {
+            panic!(
+                "local endpoint smoke test failed.\n\
+                 base_url: {}\n\
+                 model:    {}\n\
+                 error:    {}\n\
+                 \n\
+                 Make sure the local endpoint is running and the model is available.",
+                base_url, model, e
+            );
+        }
+    }
+}

--- a/src/llm/client/integration_tests.rs
+++ b/src/llm/client/integration_tests.rs
@@ -36,11 +36,11 @@ async fn local_openai_compatible_endpoint_smoke_test() {
 
     match result {
         Ok(text) => {
-            assert!(
-                !text.is_empty(),
-                "model returned an empty response"
+            assert!(!text.is_empty(), "model returned an empty response");
+            eprintln!(
+                "[integration] local endpoint smoke test passed — response length: {}",
+                text.len()
             );
-            eprintln!("[integration] local endpoint smoke test passed — response length: {}", text.len());
         }
         Err(e) => {
             panic!(

--- a/src/llm/client/mod.rs
+++ b/src/llm/client/mod.rs
@@ -7,6 +7,9 @@ mod utils;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod integration_tests;
+
 pub use llm_client::LlmClient;
 pub use types::*;
 pub use utils::generate;


### PR DESCRIPTION
## Goal

Add an ignored/manual integration test that can validate a real local OpenAI-compatible endpoint, such as Ollama or LM Studio, without running in normal CI.

This test must not run by default.

## Usage

\\\ash
PROMETHEOS_TEST_LOCAL_BASE_URL=http://localhost:11434 \
PROMETHEOS_TEST_LOCAL_MODEL=ornith \
cargo test local_openai_compatible_endpoint -- --ignored
\\\

## What's included

- New \src/llm/client/integration_tests.rs\ with \#[ignore]\d async test
- Clear error messages when env vars are missing or endpoint fails
- Release checklist updated with optional manual item

## Non-goals

- No Ollama installation
- No model downloads
- No real provider calls in CI
- No required API keys
- No automatic Ornith integration
- No benchmark claims
- No source changes