### PR TITLE
MVP: prepare alpha release draft

### DIFF
--- a/docs/release/github-release-draft-v1.6.1-alpha.1.md
+++ b/docs/release/github-release-draft-v1.6.1-alpha.1.md
@@ -1,0 +1,91 @@
+# PrometheOS Lite v1.6.1-alpha.1
+
+> ⚠️ **Alpha release.** This is a manual alpha. Review the safety model before use.
+
+PrometheOS Lite is a **local-first AI workbench** for safe autonomous software workflows. It scans repositories, creates WorkContexts, generates review artifacts, records approval decisions, and preserves memory so work can continue later.
+
+## ✨ What's in this alpha
+
+### Repo Workbench golden path
+- Create work contexts against local repositories
+- Deterministic static analysis (tree-sitter powered)
+- Reviewable risk reports and patch plan artifacts
+- Approval recording (no automatic patch application)
+- Memory persistence and work continuation
+
+### Provider architecture
+- OpenAI-compatible provider abstraction (OpenRouter, Ollama, LM Studio, BYOK)
+- Provider configuration with mode-chain routing
+- Mock HTTP provider smoke tests (no external deps)
+- Local model compatibility documentation
+
+### Provenance
+- Artifacts record whether a model was invoked
+- Deterministic Repo Workbench artifacts record "no model invoked"
+- Reviewable evidence trail
+
+### CI
+- Linux install smoke test
+- Repo Workbench golden path test
+- Source file mutation guard
+
+## 📦 Install
+
+```bash
+git clone https://github.com/prometheosai/prometheos-lite.git
+cd prometheos-lite
+cargo install --path . --force
+prometheos --version
+```
+
+## 🚀 First value in 5 minutes
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+
+prometheos work run <work_id>
+prometheos work artifacts <work_id>
+prometheos work memory show <work_id>
+```
+
+## 🛡️ Safety model
+
+| Rule | Detail |
+|---|---|
+| No source modification | `work run` analyzes, does not mutate |
+| Approval only | `work approve` records decisions, applies nothing |
+| Reviewable artifacts | All generated artifacts are human-readable |
+| Provenance tracked | Every artifact records model/provider info |
+| CI-verified | Golden path CI verifies fixture files unchanged |
+
+## 🔮 Not included (yet)
+
+- Automatic patch application
+- Full autonomous coding
+- Cloud/team control plane
+- Brain learning / Mnemosyne memory
+- Plugin marketplace
+- UI/voice layer
+- Benchmark claims
+
+## 📚 Docs
+
+- [Install guide](docs/guides/install.md)
+- [Zero-to-first-value guide](docs/guides/zero-to-first-value.md)
+- [Repo Workbench MVP guide](docs/guides/repo-workbench-mvp.md)
+- [Provider configuration guide](docs/guides/provider-configuration.md)
+- [Ollama and Ornith compatibility guide](docs/guides/ollama-ornith-compatibility.md)
+- [Local model compatibility guide](docs/guides/local-model-compatibility.md)
+
+## 🏷️ Suggested tag commands
+
+Do not run these unless explicitly authorized:
+
+```bash
+git tag -a v1.6.1-alpha.1 -m "PrometheOS Lite v1.6.1-alpha.1"
+git push origin v1.6.1-alpha.1
+```

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -51,3 +51,17 @@
 - [ ] Push git tag
 - [ ] Write release notes summarizing changes
 - [ ] Verify CI workflow runs against the tag
+
+## v1.6.1-alpha.1 manual release checklist
+
+- [ ] `main` is green
+- [ ] CI passes
+- [ ] Linux Install Smoke passes
+- [ ] Repo Workbench Golden Path passes
+- [ ] `cargo install --path . --force` verified
+- [ ] `prometheos --version` verified
+- [ ] first-value workflow verified
+- [ ] generated artifacts include provenance
+- [ ] release notes reviewed
+- [ ] GitHub Release draft reviewed
+- [ ] tag created only after approval

--- a/docs/release/v1.6.1-alpha.1.md
+++ b/docs/release/v1.6.1-alpha.1.md
@@ -1,0 +1,84 @@
+# PrometheOS Lite v1.6.1-alpha.1
+
+PrometheOS Lite is a local-first AI workbench for safe autonomous software workflows.
+
+This alpha focuses on the Repo Workbench golden path:
+
+- create a WorkContext
+- scan a repository
+- generate review artifacts
+- record approval decisions
+- preserve memory
+- continue work later
+- verify installability through CI
+
+> **Version note:** The project Cargo.toml is at `1.6.1`. This alpha release is designated `v1.6.1-alpha.1` to match the existing versioning convention. When alpha status is lifted, the version will drop the `-alpha` suffix.
+
+## What works today
+
+- installed binary: `prometheos`
+- `cargo install --path . --force`
+- `prometheos work create`
+- `prometheos work run`
+- `prometheos work artifacts`
+- `prometheos work memory show`
+- `prometheos work continue`
+- deterministic Repo Workbench analysis
+- artifact provenance metadata
+- provider configuration docs/tests
+- mock OpenAI-compatible provider tests
+- local model compatibility docs
+- optional ignored/manual local endpoint smoke test
+- Linux install smoke CI
+- golden path CI
+
+## Safety model
+
+- no automatic patch application
+- no source modification during analysis
+- `work approve` records approval only
+- generated artifacts are reviewable
+- provenance records whether a model was invoked
+- current deterministic Repo Workbench artifacts record no model invocation
+
+## What is not included yet
+
+- automatic patch application
+- full autonomous coding
+- cloud/team control plane
+- Brain learning integration
+- Mnemosyne memory backend
+- plugin marketplace
+- UI/voice layer
+- benchmark claims
+- automatic Ornith integration
+
+## Install
+
+```bash
+cargo install --path . --force
+prometheos --version
+```
+
+## First-value workflow
+
+```bash
+prometheos work create \
+  --repo fixtures/repo-workbench/rust-risky \
+  --goal "Find risky code and suggest safe improvements" \
+  --mode review \
+  --json
+
+prometheos work run <work_id>
+prometheos work artifacts <work_id>
+prometheos work memory show <work_id>
+prometheos work continue <work_id>
+```
+
+## Providers
+
+PrometheOS Lite is model-agnostic. See:
+
+- [Provider configuration guide](../guides/provider-configuration.md)
+- [Ollama and Ornith compatibility guide](../guides/ollama-ornith-compatibility.md)
+- [Local model compatibility guide](../guides/local-model-compatibility.md)


### PR DESCRIPTION
## Goal

Prepare PrometheOS Lite for a manual alpha release.

This PR does **not** publish binaries or push a tag. It creates release documentation and a GitHub Release draft body that can be copied directly into GitHub Releases.

## What's included

### New files
- `docs/release/v1.6.1-alpha.1.md` — alpha release notes
- `docs/release/github-release-draft-v1.6.1-alpha.1.md` — GitHub Release draft body

### Updated
- `docs/release/release-checklist.md` — added v1.6.1-alpha.1 checklist section

### Version note
The project Cargo.toml is at `1.6.1`. This alpha is designated `v1.6.1-alpha.1`.

## Alpha release notes cover

- What works today (golden path, providers, provenance, CI)
- Safety model
- What is not included
- Install instructions
- First-value workflow
- Provider and local model docs links

## Do not push tag unless authorized

Suggested commands are documented in the release draft but not executed:

```
git tag -a v1.6.1-alpha.1 -m "PrometheOS Lite v1.6.1-alpha.1"
git push origin v1.6.1-alpha.1
```
