### PR TITLE
docs: document frontend alpha status

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ PrometheOS Lite is not yet:
 - [Provider configuration guide](docs/guides/provider-configuration.md)
 - [Ollama and Ornith compatibility guide](docs/guides/ollama-ornith-compatibility.md)
 - [`prometheos serve` / API server status](docs/guides/serve-api-status.md)
+- [Frontend alpha status](docs/guides/frontend-alpha-status.md)
 - Architecture audit: [Provider architecture audit](docs/research/provider-architecture-audit.md)
 - [Alpha release notes](docs/release/v1.6.1-alpha.1.md)
 

--- a/docs/guides/frontend-alpha-status.md
+++ b/docs/guides/frontend-alpha-status.md
@@ -1,0 +1,113 @@
+# Frontend Alpha Status
+
+The PrometheOS Lite frontend is **experimental but present**.
+
+It exists as a local web UI surface for exploring PrometheOS Lite concepts, but it is not part of the stable alpha promise.
+
+The stable alpha path remains the CLI:
+
+```bash
+prometheos work ...
+```
+
+## Status
+
+Status: **experimental**
+
+Decision: present, documented, not stable alpha.
+
+## Why it is not stable alpha yet
+
+- Frontend CI is not part of the required release gate yet.
+- Playwright/E2E coverage is not enforced in CI yet.
+- Frontend/API integration is not part of the stable alpha golden path.
+- The stable alpha release can be used entirely through the CLI.
+- Routes and UI flows may change.
+
+## What exists
+
+- Next.js 15 application (TypeScript, Tailwind CSS, shadcn/ui)
+- Project pages (CRUD UI via `GET/POST /projects`)
+- Conversation UI (chat interface with sidebar layout)
+- Settings and profile pages
+- Search command palette (CMDK-based)
+- WebSocket flow event UI (streams execution events from `ws://127.0.0.1:3000/ws/runs/:id`)
+
+## How it relates to the API server
+
+The frontend depends on the experimental API server.
+
+The default configuration is:
+
+| Component | Default URL | Notes |
+|-----------|-------------|-------|
+| API server | `http://127.0.0.1:3000` | Started via `prometheos serve` |
+| Frontend dev server | `http://localhost:3001` | Started via `npm run dev` |
+| WebSocket | `ws://127.0.0.1:3000/ws/runs/:id` | Hardcoded in `src/lib/api.ts` |
+
+To run both locally:
+
+```bash
+# Terminal 1: start the API server
+prometheos serve
+
+# Terminal 2: start the frontend
+cd frontend
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3001`.
+
+## How it relates to Repo Workbench
+
+Repo Workbench does not require the frontend.
+
+The stable alpha workflow remains:
+
+```bash
+prometheos work create ...
+prometheos work run ...
+prometheos work artifacts ...
+prometheos work memory show ...
+prometheos work continue ...
+```
+
+## What is safe to rely on
+
+Safe to rely on for alpha:
+
+- CLI golden path
+- Repo Workbench artifacts
+- Provenance
+- Local file-backed workbench state
+- Documented provider configuration
+
+Not safe to rely on yet:
+
+- Frontend UI flows
+- Frontend/API route compatibility
+- Frontend build stability
+- Visual regression coverage
+- Production deployment behavior
+
+## Current decision
+
+The frontend stays in the repo as an experimental surface.
+
+It should not be removed.
+
+It should not be promoted to stable alpha until at least:
+
+- Frontend build is verified in CI.
+- Lint/typecheck pass in CI.
+- At least one smoke or E2E test is enforced.
+- API server compatibility is covered by smoke tests.
+- README and alpha docs are updated accordingly.
+
+## Next recommended PRs
+
+- Add frontend build/typecheck CI.
+- Add API server smoke test.
+- Add minimal frontend smoke/E2E test.
+- Document local frontend demo once CI proves it.

--- a/docs/guides/serve-api-status.md
+++ b/docs/guides/serve-api-status.md
@@ -94,6 +94,8 @@ The frontend uses:
 
 The frontend is an **experimental** web UI surface. It is not the stable alpha entrypoint. The stable alpha path remains the CLI.
 
+See the [Frontend Alpha Status](docs/guides/frontend-alpha-status.md) guide for the full decision.
+
 ## Relationship to Repo Workbench
 
 Repo Workbench (`prometheos work`) does not require the API server.

--- a/docs/guides/serve-api-status.md
+++ b/docs/guides/serve-api-status.md
@@ -94,7 +94,7 @@ The frontend uses:
 
 The frontend is an **experimental** web UI surface. It is not the stable alpha entrypoint. The stable alpha path remains the CLI.
 
-See the [Frontend Alpha Status](docs/guides/frontend-alpha-status.md) guide for the full decision.
+See the [Frontend Alpha Status](frontend-alpha-status.md) guide for the full decision.
 
 ## Relationship to Repo Workbench
 


### PR DESCRIPTION
## Summary

Documents the PrometheOS Lite frontend as experimental but present.

The frontend exists in the repository and can be used for local exploration, but it is not part of the stable alpha promise. The stable alpha path remains \prometheos work\ / Repo Workbench.

## What changed

- Added \docs/guides/frontend-alpha-status.md\.
- Linked frontend status from the README.
- Cross-linked from the \prometheos serve\ / API server status guide.
- Kept frontend status experimental.
- Preserved CLI / Repo Workbench as the stable alpha path.

## Decision

Frontend status: **experimental but present**.

It should not be removed, but it should not be promoted to stable alpha until frontend CI/build/E2E coverage exists.

## Safety model

Documentation-only PR.

No runtime behavior changed.

No API behavior changed.

No frontend behavior changed.

No source-modifying behavior changed.

No new surface promoted to stable alpha.

## Verification

- [x] \cargo fmt --check\
- [x] \cargo check\
- [x] \cargo test\ (561 passed, 0 failed, 3 ignored)
- [x] \cargo clippy --all-targets --all-features -- -D warnings\
- [ ] \cd frontend && npm run build\ — pre-existing TS error (Next.js 15 params type change), not caused by this PR

## Follow-ups

- Add frontend build/typecheck CI.
- Add API server smoke test.
- Add minimal frontend smoke/E2E test.
- Document a local frontend demo once CI proves it.