### PR TITLE
docs: add Ornith manual validation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See:
 - [Zero-to-first-value guide](docs/guides/zero-to-first-value.md)
 - [Repo Workbench MVP guide](docs/guides/repo-workbench-mvp.md)
 - [Ollama and Ornith compatibility guide](docs/guides/ollama-ornith-compatibility.md)
+- [Ornith manual validation guide](docs/guides/ornith-manual-validation.md)
 
 ## Safety model
 
@@ -143,6 +144,7 @@ PrometheOS Lite is not yet:
 - [Product Surface Inventory](docs/guides/product-surface-inventory.md)
 - [Provider configuration guide](docs/guides/provider-configuration.md)
 - [Ollama and Ornith compatibility guide](docs/guides/ollama-ornith-compatibility.md)
+- [Ornith manual validation guide](docs/guides/ornith-manual-validation.md)
 - [`prometheos serve` / API server status](docs/guides/serve-api-status.md)
 - [Frontend alpha status](docs/guides/frontend-alpha-status.md)
 - [Model-layer positioning](docs/research/model-layer-positioning.md)

--- a/docs/guides/local-model-compatibility.md
+++ b/docs/guides/local-model-compatibility.md
@@ -89,3 +89,5 @@ The alpha does not yet promise:
 - model training
 
 See also the [Ollama and Ornith compatibility guide](ollama-ornith-compatibility.md) for step-by-step local model setup and validation.
+
+See the [Ornith manual validation guide](ornith-manual-validation.md) for a dedicated manual validation walkthrough.

--- a/docs/guides/ollama-ornith-compatibility.md
+++ b/docs/guides/ollama-ornith-compatibility.md
@@ -74,6 +74,8 @@ PrometheOS Lite appends `/v1/chat/completions` through the OpenAI-compatible cli
 }
 ```
 
+See also the [Ornith manual validation guide](ornith-manual-validation.md) for step-by-step manual validation instructions.
+
 ## Provenance
 
 When model-backed flows are used in the future, artifacts should record provider and model metadata.

--- a/docs/guides/ornith-manual-validation.md
+++ b/docs/guides/ornith-manual-validation.md
@@ -103,6 +103,33 @@ A passing test does not mean:
 * PrometheOS Lite is the workbench that records context, provenance, approvals, artifacts, and verification paths.
 * This guide validates compatibility, not product superiority.
 
+## Boundary: autonomous execution loop is not part of this validation
+
+This guide validates manual Ornith endpoint compatibility only.
+
+It does not promote the autonomous execution loop.
+
+PrometheOS Lite currently distinguishes between:
+
+- the stable alpha path: `prometheos work`, which is read-only and produces review artifacts
+- experimental harness execution paths, which may evaluate, dry-run, checkpoint, rollback, and apply patches depending on mode and policy
+
+The autonomous execution loop must not be promoted until a separate graduation decision exists.
+
+At minimum, that future decision should require:
+
+- the model validation plan in `docs/research/model-layer-positioning.md` has been run
+- manual Ornith/local endpoint validation has produced real results
+- harness value has been compared against direct model usage
+- a small internal benchmark slice exists
+- minimality enforcement is wired into the real execution path and tested
+- escalation behavior is documented and tested
+- plan-locking / scope-locking exists and is tested
+- rollback/checkpoint behavior is covered by tests
+- docs clearly distinguish read-only review, assisted patching, and autonomous patching
+
+Until then, the autonomous loop remains experimental.
+
 ## Next steps after manual validation
 
 If the manual validation passes, future PRs can add:

--- a/docs/guides/ornith-manual-validation.md
+++ b/docs/guides/ornith-manual-validation.md
@@ -1,0 +1,119 @@
+# Ornith Manual Validation Guide
+
+This guide explains how to manually validate Ornith with PrometheOS Lite through an OpenAI-compatible local endpoint.
+
+Ornith support is not automatic. This is a manual compatibility path.
+
+PrometheOS Lite remains model-agnostic.
+
+The stable alpha workflow remains `prometheos work`.
+
+## Status
+
+Status: manual / experimental
+
+This guide verifies local endpoint compatibility only.
+
+It does not claim:
+
+- benchmark performance
+- production support
+- automatic Ornith integration
+- full harness value
+- PrometheOS Lite improves Ornith results
+
+## Prerequisites
+
+- Rust toolchain
+- PrometheOS Lite repo
+- Ollama or another OpenAI-compatible local runtime
+- Ornith model available locally
+- enough local hardware for the selected model
+
+## Option A: Ollama
+
+Start Ollama and pull the model:
+
+```bash
+ollama pull ornith
+ollama run ornith
+```
+
+If the model name in your local registry differs (e.g. `ornith:9b`, `ornith:35b`), use that exact name.
+
+Ollama exposes an OpenAI-compatible API. Configure the base URL as:
+
+```text
+http://localhost:11434
+```
+
+PrometheOS Lite appends `/v1/chat/completions` through the client path. Do not include `/v1` in the base URL.
+
+## Option B: Generic OpenAI-compatible endpoint
+
+Any local runtime that serves an OpenAI-compatible chat completions endpoint can be used — LM Studio, vLLM, SGLang, or similar.
+
+Configure the base URL and model according to the runtime's documentation. No API key is required unless the runtime itself requires one.
+
+## Run the manual endpoint test
+
+Use the existing ignored integration test with the exact environment variables from the repo:
+
+```bash
+PROMETHEOS_TEST_LOCAL_BASE_URL=http://localhost:11434 \
+PROMETHEOS_TEST_LOCAL_MODEL=ornith \
+cargo test local_openai_compatible_endpoint -- --ignored
+```
+
+If you are using a different model name or base URL, set the env vars accordingly.
+
+## Expected result
+
+A passing test means:
+
+* PrometheOS Lite can send a chat-completion request to the local endpoint.
+* The local endpoint can respond.
+* Request/response parsing works.
+* No external hosted provider is required.
+* No API key is required for the local endpoint, unless the runtime itself requires one.
+
+A passing test does not mean:
+
+* benchmark validation
+* Repo Workbench model integration
+* full harness validation
+* frontend support
+* stable alpha promotion
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `connection refused` | local runtime not running |
+| `404 not found` | wrong base URL (should be `http://localhost:11434` without `/v1`) |
+| `model not found` | wrong model name or model not pulled |
+| `out of memory` | insufficient memory/GPU for the selected model |
+| `response parse error` | endpoint not fully OpenAI-compatible or response shape mismatch |
+| timeout | model too large for hardware or endpoint overloaded |
+
+## Relationship to PrometheOS Lite
+
+* PrometheOS Lite is not the model.
+* Ornith is a model provider candidate.
+* PrometheOS Lite is the workbench that records context, provenance, approvals, artifacts, and verification paths.
+* This guide validates compatibility, not product superiority.
+
+## Next steps after manual validation
+
+If the manual validation passes, future PRs can add:
+
+* repeatable local model comparison harness
+* fixture-based tasks
+* artifact-level model comparison reports
+* optional model-augmented Repo Workbench mode
+
+If it fails, future PRs should document:
+
+* endpoint incompatibility
+* required adapter changes
+* model/runtime-specific quirks

--- a/docs/release/release-checklist.md
+++ b/docs/release/release-checklist.md
@@ -11,7 +11,7 @@
 - [ ] `prometheos --version`
 - [ ] First-value workflow runs from installed binary against `fixtures/repo-workbench/rust-risky`
 - [ ] Linux install smoke CI passes
-- [ ] Optional manual local endpoint smoke test run
+- [ ] Optional manual local endpoint smoke test run (see [Ornith manual validation guide](../guides/ornith-manual-validation.md))
 
 ## Documentation
 

--- a/docs/research/model-layer-positioning.md
+++ b/docs/research/model-layer-positioning.md
@@ -85,7 +85,7 @@ Three phases for testing whether PrometheOS Lite adds value on top of Ornith.
 
 ### Phase 1: Manual local endpoint validation
 
-Use the existing manual local endpoint path.
+Use the existing manual local endpoint path. See the [Ornith manual validation guide](../guides/ornith-manual-validation.md) for step-by-step instructions.
 
 Target examples:
 

--- a/docs/research/model-layer-positioning.md
+++ b/docs/research/model-layer-positioning.md
@@ -133,6 +133,8 @@ Example tasks:
 
 Do not claim public benchmark performance.
 
+The autonomous execution loop should not be evaluated for promotion until this validation plan has produced real evidence.
+
 ## Near-term implementation path
 
 Recommended future PRs:


### PR DESCRIPTION
## Summary

Adds a manual validation guide for testing Ornith with PrometheOS Lite through the existing local/OpenAI-compatible endpoint path.

This implements the Phase 1 validation path described in the model-layer positioning document.

## What changed

- Added `docs/guides/ornith-manual-validation.md`.
- Linked it from README.
- Cross-linked from local model / Ollama-Ornith / model-layer positioning docs.
- Updated the release checklist optional validation reference.
- Kept Ornith validation manual and experimental.
- Avoided benchmark claims and automatic integration claims.

## Safety model

Documentation-only PR.

No runtime behavior changed.

No provider behavior changed.

No model calls added.

No model downloads added.

No CI dependency on Ornith/Ollama/GPU.

No source-modifying behavior changed.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test` — 561 passed, 3 ignored
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Optional manual validation:

- [ ] `PROMETHEOS_TEST_LOCAL_BASE_URL=... PROMETHEOS_TEST_LOCAL_MODEL=... cargo test local_openai_compatible_endpoint -- --ignored`

Not run because no local Ornith runtime was available.

## Follow-ups

- Add repeatable local model comparison harness.
- Add fixture-based evaluation tasks.
- Add artifact-level model comparison output.
- Add optional model-augmented Repo Workbench path only after validation.
