### PR TITLE
MVP: add assembled API router smoke test

### DIFF
--- a/docs/guides/serve-api-status.md
+++ b/docs/guides/serve-api-status.md
@@ -117,7 +117,9 @@ Current stable alpha guarantees remain:
 ## Limitations
 
 - Not part of stable alpha golden path.
-- A minimal API smoke test verifies safe endpoints (`/health`, `/runtime/stack`). Broader API route coverage remains experimental.
+- A minimal API smoke test verifies `/health` and `/runtime/stack`.
+- An assembled router smoke test verifies those safe endpoints are wired through the API router used by `prometheos serve`.
+- Broader API route coverage remains experimental.
 - Frontend is not stable alpha.
 - Routes may change.
 - No authentication/authorization middleware — user identity is a query parameter.
@@ -128,4 +130,4 @@ Current stable alpha guarantees remain:
 
 ## Next step
 
-Now that a minimal API smoke test exists, the next step is adding broader API route coverage.
+Now that handler-level and assembled-router smoke tests exist for safe endpoints, the next step is adding broader API route coverage.

--- a/tests/api_server_smoke.rs
+++ b/tests/api_server_smoke.rs
@@ -7,6 +7,44 @@ use axum::Router;
 use axum::routing::get;
 use tower::ServiceExt;
 
+/// Helper: build a minimal AppState for testing the assembled API router.
+/// Returns (AppState, TempDir) so the caller keeps the tempdir alive.
+fn test_app_state() -> (
+    std::sync::Arc<prometheos_lite::api::AppState>,
+    tempfile::TempDir,
+) {
+    let db_dir = tempfile::tempdir().expect("temp db dir");
+    let db_path = db_dir
+        .path()
+        .join("api_smoke_test.db")
+        .to_str()
+        .expect("db path")
+        .to_string();
+
+    let runtime = std::sync::Arc::new(prometheos_lite::flow::runtime::RuntimeContext::new());
+    let embedding: std::sync::Arc<dyn prometheos_lite::flow::EmbeddingProvider> =
+        std::sync::Arc::new(prometheos_lite::flow::memory::LocalEmbeddingProvider::new(
+            "http://127.0.0.1:9/embeddings".to_string(),
+            8,
+            None,
+        ));
+    let memory_service = std::sync::Arc::new(prometheos_lite::flow::memory::MemoryService::new(
+        prometheos_lite::flow::memory::MemoryDb::in_memory().expect("in-memory memory db"),
+        Box::new(prometheos_lite::flow::memory::LocalEmbeddingProvider::new(
+            "http://127.0.0.1:9/embeddings".to_string(),
+            8,
+            None,
+        )),
+    ));
+
+    let state = std::sync::Arc::new(
+        prometheos_lite::api::AppState::new(db_path, runtime, embedding, memory_service)
+            .expect("app state"),
+    );
+
+    (state, db_dir)
+}
+
 #[tokio::test]
 async fn api_server_router_constructs_and_serves_health() {
     let app = Router::new().route("/health", get(prometheos_lite::api::health::health_check));
@@ -42,4 +80,51 @@ async fn api_server_router_constructs_and_serves_runtime_stack() {
         .unwrap();
 
     assert_eq!(response.status(), 200);
+}
+
+#[tokio::test]
+async fn assembled_api_router_serves_safe_endpoints() {
+    let (state, _db_dir) = test_app_state();
+    let app = prometheos_lite::api::router::create_router(state);
+
+    let response = app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/health")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/runtime/stack")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+}
+
+#[tokio::test]
+async fn assembled_api_router_rejects_unknown_route() {
+    let (state, _db_dir) = test_app_state();
+    let app = prometheos_lite::api::router::create_router(state);
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/definitely-not-a-real-route")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 404);
 }


### PR DESCRIPTION
## Summary

Adds assembled API router smoke coverage for the experimental `prometheos serve` API surface.

PR #55 added minimal handler-level smoke tests for `/health` and `/runtime/stack` using standalone test routers.

This PR verifies those safe endpoints through the assembled API router path used by `prometheos serve` (`create_router` in `src/api/router.rs`), using the same AppState construction pattern already established in `work_contexts.rs`.

## What changed

- Added assembled router smoke coverage for `/health` and `/runtime/stack` via `create_router`.
- Added a 404 unknown-route test via the assembled router.
- Updated API status docs to distinguish handler-level smoke coverage from assembled-router coverage.
- Kept API server status experimental.

## Safety model

No model invocation.

No provider calls.

No API keys required.

No external services.

No frontend dependency.

No source modification.

No patch application.

No autonomous execution behavior changed.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test` — 4 tests in api_server_smoke (2 existing handler-level, 2 new assembled-router)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

## Follow-ups

- Add broader API route coverage.
- Add ownership/validation coverage for more API surfaces.
- Add frontend build/typecheck CI.
- Add minimal frontend smoke/E2E only after API coverage is stronger.
