### PR TITLE
MVP: add frontend build/typecheck CI gate

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,42 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-typecheck:
+    name: Build & Typecheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
   push:
     branches: [main]
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
 
 permissions:
   contents: read
@@ -31,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/docs/guides/frontend-alpha-status.md
+++ b/docs/guides/frontend-alpha-status.md
@@ -18,7 +18,7 @@ Decision: present, documented, not stable alpha.
 
 ## Why it is not stable alpha yet
 
-- Frontend CI is not part of the required release gate yet.
+- Frontend CI (build & typecheck) is now gated on PRs via `.github/workflows/frontend-ci.yml`.
 - Playwright/E2E coverage is not enforced in CI yet.
 - Frontend/API integration is not part of the stable alpha golden path.
 - The stable alpha release can be used entirely through the CLI.
@@ -82,12 +82,12 @@ Safe to rely on for alpha:
 - Provenance
 - Local file-backed workbench state
 - Documented provider configuration
+- Frontend build & typecheck (enforced in CI via `.github/workflows/frontend-ci.yml`)
 
 Not safe to rely on yet:
 
 - Frontend UI flows
 - Frontend/API route compatibility
-- Frontend build stability
 - Visual regression coverage
 - Production deployment behavior
 
@@ -99,15 +99,14 @@ It should not be removed.
 
 It should not be promoted to stable alpha until at least:
 
-- Frontend build is verified in CI.
-- Lint/typecheck pass in CI.
-- At least one smoke or E2E test is enforced.
-- API server compatibility is covered by smoke tests.
-- README and alpha docs are updated accordingly.
+- [x] Frontend build is verified in CI (PR #60).
+- [ ] Lint/typecheck pass in CI.
+- [ ] At least one smoke or E2E test is enforced.
+- [ ] API server compatibility is covered by smoke tests.
+- [ ] README and alpha docs are updated accordingly.
 
 ## Next recommended PRs
 
-- Add frontend build/typecheck CI.
-- Add API server smoke test.
+- Add frontend lint/typecheck CI.
 - Add minimal frontend smoke/E2E test.
 - Document local frontend demo once CI proves it.

--- a/frontend/src/app/conversations/[id]/page.tsx
+++ b/frontend/src/app/conversations/[id]/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { Send, ArrowLeft, Clock, FileText, Loader2, Moon, Sun } from 'lucide-react';
 import { getMessages, runFlow, connectWebSocket, type Message, type FlowEvent } from '@/lib/api';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 
-export default function ConversationPage({ params }: { params: Promise<{ id: string }> }) {
-  const p = params as unknown as { id: string };
+export default function ConversationPage() {
+  const { id } = useParams<{ id: string }>();
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(true);
@@ -25,7 +25,7 @@ export default function ConversationPage({ params }: { params: Promise<{ id: str
         wsRef.current.close();
       }
     };
-  }, [p.id]);
+  }, [id]);
 
   useEffect(() => {
     scrollToBottom();
@@ -37,7 +37,7 @@ export default function ConversationPage({ params }: { params: Promise<{ id: str
 
   const loadMessages = async () => {
     try {
-      const data = await getMessages(p.id);
+      const data = await getMessages(id);
       setMessages(data);
     } catch (error) {
       console.error('Failed to load messages:', error);
@@ -59,7 +59,7 @@ export default function ConversationPage({ params }: { params: Promise<{ id: str
     // Add user message immediately to the UI
     const tempUserMessage: Message = {
       id: `temp-${Date.now()}`,
-      conversation_id: p.id,
+      conversation_id: id,
       role: 'user',
       content: userMessage,
       created_at: new Date().toISOString(),
@@ -68,7 +68,7 @@ export default function ConversationPage({ params }: { params: Promise<{ id: str
 
     try {
       // Run flow which saves the message and starts execution
-      const flowRun = await runFlow(p.id, userMessage);
+      const flowRun = await runFlow(id, userMessage);
 
       // Connect WebSocket for live updates
       const ws = connectWebSocket(flowRun.id, (event) => {
@@ -85,7 +85,7 @@ export default function ConversationPage({ params }: { params: Promise<{ id: str
           setRunning(false);
           const assistantMessage: Message = {
             id: `assistant-${Date.now()}`,
-            conversation_id: p.id,
+            conversation_id: id,
             role: 'assistant',
             content: event.data.data,
             created_at: new Date().toISOString(),

--- a/frontend/src/app/conversations/[id]/page.tsx
+++ b/frontend/src/app/conversations/[id]/page.tsx
@@ -5,7 +5,8 @@ import { Send, ArrowLeft, Clock, FileText, Loader2, Moon, Sun } from 'lucide-rea
 import { getMessages, runFlow, connectWebSocket, type Message, type FlowEvent } from '@/lib/api';
 import { useRouter } from 'next/navigation';
 
-export default function ConversationPage({ params }: { params: { id: string } }) {
+export default function ConversationPage({ params }: { params: Promise<{ id: string }> }) {
+  const p = params as unknown as { id: string };
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(true);
@@ -24,7 +25,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
         wsRef.current.close();
       }
     };
-  }, [params.id]);
+  }, [p.id]);
 
   useEffect(() => {
     scrollToBottom();
@@ -36,7 +37,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
 
   const loadMessages = async () => {
     try {
-      const data = await getMessages(params.id);
+      const data = await getMessages(p.id);
       setMessages(data);
     } catch (error) {
       console.error('Failed to load messages:', error);
@@ -58,7 +59,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
     // Add user message immediately to the UI
     const tempUserMessage: Message = {
       id: `temp-${Date.now()}`,
-      conversation_id: params.id,
+      conversation_id: p.id,
       role: 'user',
       content: userMessage,
       created_at: new Date().toISOString(),
@@ -67,7 +68,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
 
     try {
       // Run flow which saves the message and starts execution
-      const flowRun = await runFlow(params.id, userMessage);
+      const flowRun = await runFlow(p.id, userMessage);
 
       // Connect WebSocket for live updates
       const ws = connectWebSocket(flowRun.id, (event) => {
@@ -84,7 +85,7 @@ export default function ConversationPage({ params }: { params: { id: string } })
           setRunning(false);
           const assistantMessage: Message = {
             id: `assistant-${Date.now()}`,
-            conversation_id: params.id,
+            conversation_id: p.id,
             role: 'assistant',
             content: event.data.data,
             created_at: new Date().toISOString(),

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useEffect } from 'react';
 import { Plus, MessageSquare, ArrowLeft } from 'lucide-react';
 import { getConversations, createConversation, type Conversation } from '@/lib/api';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 
-export default function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
-  const p = params as unknown as { id: string };
+export default function ProjectPage() {
+  const { id } = useParams<{ id: string }>();
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [newConversationTitle, setNewConversationTitle] = useState('');
   const [loading, setLoading] = useState(true);
@@ -14,11 +14,11 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
 
   useEffect(() => {
     loadConversations();
-  }, [p.id]);
+  }, [id]);
 
   const loadConversations = async () => {
     try {
-      const data = await getConversations(p.id);
+      const data = await getConversations(id);
       setConversations(data);
     } catch (error) {
       console.error('Failed to load conversations:', error);
@@ -32,7 +32,7 @@ export default function ProjectPage({ params }: { params: Promise<{ id: string }
     if (!newConversationTitle.trim()) return;
 
     try {
-      const conversation = await createConversation(p.id, newConversationTitle);
+      const conversation = await createConversation(id, newConversationTitle);
       setConversations([...conversations, conversation]);
       setNewConversationTitle('');
     } catch (error) {

--- a/frontend/src/app/projects/[id]/page.tsx
+++ b/frontend/src/app/projects/[id]/page.tsx
@@ -5,7 +5,8 @@ import { Plus, MessageSquare, ArrowLeft } from 'lucide-react';
 import { getConversations, createConversation, type Conversation } from '@/lib/api';
 import { useRouter } from 'next/navigation';
 
-export default function ProjectPage({ params }: { params: { id: string } }) {
+export default function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
+  const p = params as unknown as { id: string };
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [newConversationTitle, setNewConversationTitle] = useState('');
   const [loading, setLoading] = useState(true);
@@ -13,11 +14,11 @@ export default function ProjectPage({ params }: { params: { id: string } }) {
 
   useEffect(() => {
     loadConversations();
-  }, [params.id]);
+  }, [p.id]);
 
   const loadConversations = async () => {
     try {
-      const data = await getConversations(params.id);
+      const data = await getConversations(p.id);
       setConversations(data);
     } catch (error) {
       console.error('Failed to load conversations:', error);
@@ -31,7 +32,7 @@ export default function ProjectPage({ params }: { params: { id: string } }) {
     if (!newConversationTitle.trim()) return;
 
     try {
-      const conversation = await createConversation(params.id, newConversationTitle);
+      const conversation = await createConversation(p.id, newConversationTitle);
       setConversations([...conversations, conversation]);
       setNewConversationTitle('');
     } catch (error) {


### PR DESCRIPTION
## Summary

Adds frontend build/typecheck CI coverage for the experimental PrometheOS Lite frontend.

The frontend remains experimental and is not promoted to stable alpha.

## What changed

- Added `.github/workflows/frontend-ci.yml`.
- Verified frontend dependency install with `npm ci`.
- Verified frontend build with `npm run build`.
- Fixed minimal frontend build/typecheck blockers (Next.js 15 `PageProps` `params` type).
- Updated `docs/guides/frontend-alpha-status.md` to reflect current CI coverage and remaining promotion blockers.

## Frontend status

Status remains experimental.

This PR only adds build/typecheck confidence.

It does not add E2E coverage, visual regression coverage, frontend/API compatibility guarantees, or production deployment support.

## Safety model

No Rust runtime behavior changed.

No API behavior changed.

No provider/model calls added.

No source-modifying behavior changed.

No autonomous execution behavior changed.

No frontend stable-alpha promotion.

## Verification

Rust:

- [X] `cargo fmt --check`
- [X] `cargo check`
- [X] `cargo test`
- [X] `cargo clippy --all-targets --all-features -- -D warnings`

Frontend:

- [X] `cd frontend && npm ci`
- [X] `cd frontend && npm run build`

## Follow-ups

- Add minimal frontend smoke/E2E test.
- Add frontend/API compatibility smoke once routes are more covered.
- Document a local frontend demo after CI proves the surface.
