### PR TITLE
docs: add local frontend demo guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ PrometheOS Lite is not yet:
 - [Ornith manual validation guide](docs/guides/ornith-manual-validation.md)
 - [`prometheos serve` / API server status](docs/guides/serve-api-status.md)
 - [Frontend alpha status](docs/guides/frontend-alpha-status.md)
+- [Local frontend demo](docs/guides/local-frontend-demo.md)
 - [Model-layer positioning](docs/research/model-layer-positioning.md)
 - [Autonomous loop graduation criteria](docs/research/autonomous-loop-graduation-criteria.md)
 - Architecture audit: [Provider architecture audit](docs/research/provider-architecture-audit.md)

--- a/docs/guides/frontend-alpha-status.md
+++ b/docs/guides/frontend-alpha-status.md
@@ -45,6 +45,8 @@ The default configuration is:
 | Frontend dev server | `http://localhost:3001` | Started via `npm run dev` |
 | WebSocket | `ws://127.0.0.1:3000/ws/runs/:id` | Hardcoded in `src/lib/api.ts` |
 
+For a focused walkthrough, see the [Local Frontend Demo](local-frontend-demo.md) guide.
+
 To run both locally:
 
 ```bash
@@ -109,4 +111,4 @@ It should not be promoted to stable alpha until at least:
 
 - Add frontend lint/typecheck CI.
 - Add minimal frontend smoke/E2E test.
-- Document local frontend demo once CI proves it.
+- Add frontend/API compatibility smoke once route coverage is stronger.

--- a/docs/guides/local-frontend-demo.md
+++ b/docs/guides/local-frontend-demo.md
@@ -1,0 +1,139 @@
+# Local Frontend Demo
+
+The PrometheOS Lite frontend is experimental but runnable locally.
+
+This guide shows how to run the local frontend together with the experimental API server.
+
+The stable alpha workflow remains `prometheos work`.
+
+## Status
+
+Status: experimental.
+
+This demo is for local exploration only.
+
+It does not promote the frontend to stable alpha.
+
+## What this demo shows
+
+This local demo can show:
+
+- the experimental Next.js frontend
+- the experimental API server
+- project and conversation UI surfaces
+- frontend/API communication against a local server
+- local WebSocket event wiring if the corresponding backend route is exercised
+
+## What this demo does not claim
+
+This demo does not claim:
+
+- stable frontend support
+- production deployment support
+- full frontend/API compatibility
+- E2E coverage
+- visual regression coverage
+- authentication or authorization coverage
+- cloud/team control plane behavior
+- Brain or Mnemosyne integration
+- autonomous execution safety
+
+## Prerequisites
+
+- Rust toolchain
+- Node.js 20
+- npm
+- PrometheOS Lite repo checked out locally
+- frontend dependencies installable with `npm ci`
+
+## Terminal 1: start the API server
+
+From the repo root:
+
+```bash
+prometheos serve
+```
+
+By default, the API server binds to:
+
+```text
+http://127.0.0.1:3000
+```
+
+Verify the API server:
+
+```bash
+curl http://127.0.0.1:3000/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+Optional runtime stack check:
+
+```bash
+curl http://127.0.0.1:3000/runtime/stack
+```
+
+## Terminal 2: start the frontend
+
+From the repo root:
+
+```bash
+cd frontend
+npm ci
+npm run dev
+```
+
+The frontend dev server runs at:
+
+```text
+http://localhost:3001
+```
+
+Open that URL in a browser.
+
+## Build check
+
+To verify the frontend build locally:
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+The same build path is checked in CI by `.github/workflows/frontend-ci.yml`.
+
+## Current limitations
+
+The frontend remains experimental.
+
+Known limitations:
+
+* no E2E test is enforced yet
+* no Playwright coverage yet
+* frontend/API route compatibility is not fully covered
+* no visual regression coverage
+* no production deployment guarantee
+* lint is not enforced in CI yet
+* routes and UI flows may change
+
+## Relationship to stable alpha
+
+The stable alpha workflow does not require the frontend.
+
+Use this for the stable local workflow:
+
+```bash
+prometheos work create --repo . --goal "Review this repository" --mode review
+prometheos work run <work_id>
+prometheos work artifacts <work_id>
+prometheos work memory show <work_id>
+prometheos work continue <work_id>
+```
+
+Use the frontend demo only for local exploration of the experimental UI.

--- a/docs/guides/serve-api-status.md
+++ b/docs/guides/serve-api-status.md
@@ -94,6 +94,8 @@ The frontend uses:
 
 The frontend is an **experimental** web UI surface. It is not the stable alpha entrypoint. The stable alpha path remains the CLI.
 
+For the local two-terminal walkthrough, see the [Local Frontend Demo](local-frontend-demo.md) guide.
+
 See the [Frontend Alpha Status](frontend-alpha-status.md) guide for the full decision.
 
 ## Relationship to Repo Workbench


### PR DESCRIPTION
## Summary

Adds a local frontend demo guide for running the experimental PrometheOS Lite frontend with the experimental API server.

The frontend remains experimental and is not promoted to stable alpha.

## What changed

- Added `docs/guides/local-frontend-demo.md`.
- Documented the two-terminal local demo path:
  - `prometheos serve`
  - `cd frontend && npm ci && npm run dev`
- Linked the guide from README.
- Linked the guide from frontend/API status docs.
- Kept `prometheos work` as the stable alpha path.

## Frontend status

Status remains experimental.

This PR documents local exploration only.

It does not add E2E coverage, visual regression coverage, frontend/API compatibility guarantees, auth guarantees, or production deployment support.

## Safety model

Docs-only PR.

No Rust runtime behavior changed.

No API behavior changed.

No frontend runtime behavior changed.

No provider/model calls added.

No source-modifying behavior changed.

No autonomous execution behavior changed.

No frontend stable-alpha promotion.

## Verification

Rust:

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Frontend:

- [x] `cd frontend && npm ci`
- [x] `cd frontend && npm run build`

Manual local demo:

- [ ] Manual local demo not run in this PR.

## Follow-ups

- Add frontend lint/typecheck CI.
- Add minimal frontend smoke/E2E test.
- Add frontend/API compatibility smoke once route coverage is stronger.
