### PR TITLE
docs: add PrometheOS Lite Loop Engineering Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ PrometheOS Lite is not yet:
 - [Model-layer positioning](docs/research/model-layer-positioning.md)
 - [Autonomous loop graduation criteria](docs/research/autonomous-loop-graduation-criteria.md)
 - Architecture audit: [Provider architecture audit](docs/research/provider-architecture-audit.md)
+- [Loop Engineering Protocol](docs/LOOP_ENGINEERING.md) — operating protocol for agent-assisted development
 - [Alpha release notes](docs/release/v1.6.1-alpha.1.md)
 
 ---

--- a/docs/LOOP_ENGINEERING.md
+++ b/docs/LOOP_ENGINEERING.md
@@ -158,15 +158,15 @@ Do not promote. Only work on it under explicit scope and with the autonomous loo
 
 ## Related files
 
-- [Agent Protocol](specs/loop-engineering/AGENT_PROTOCOL.md) — detailed agent instructions
-- [Safety Gates](specs/loop-engineering/SAFETY_GATES.md) — hard blockers and soft warnings
-- [PR Template](specs/loop-engineering/PR_TEMPLATE.md) — required PR body format
-- [Handoff Template](specs/loop-engineering/HANDOFF_TEMPLATE.md) — handoff report format
-- [Progress Schema](specs/loop-engineering/PROGRESS_SCHEMA.md) — progress tracking format
-- [Task Queue Template](specs/loop-engineering/TASK_QUEUE_TEMPLATE.md) — queue definition format
-- [Comment Templates](specs/loop-engineering/COMMENT_TEMPLATES.md) — standardized issue/PR comments
+- [Agent Protocol](../specs/loop-engineering/AGENT_PROTOCOL.md) — detailed agent instructions
+- [Safety Gates](../specs/loop-engineering/SAFETY_GATES.md) — hard blockers and soft warnings
+- [PR Template](../specs/loop-engineering/PR_TEMPLATE.md) — required PR body format
+- [Handoff Template](../specs/loop-engineering/HANDOFF_TEMPLATE.md) — handoff report format
+- [Progress Schema](../specs/loop-engineering/PROGRESS_SCHEMA.md) — progress tracking format
+- [Task Queue Template](../specs/loop-engineering/TASK_QUEUE_TEMPLATE.md) — queue definition format
+- [Comment Templates](../specs/loop-engineering/COMMENT_TEMPLATES.md) — standardized issue/PR comments
 
 ## See also
 
 - [Product Surface Inventory](guides/product-surface-inventory.md)
-- [Autonomous Loop Graduation Criteria](../research/autonomous-loop-graduation-criteria.md)
+- [Autonomous Loop Graduation Criteria](research/autonomous-loop-graduation-criteria.md)

--- a/docs/LOOP_ENGINEERING.md
+++ b/docs/LOOP_ENGINEERING.md
@@ -1,0 +1,172 @@
+# Loop Engineering Protocol
+
+A repository-native operating protocol for PrometheOS Lite that defines how coding agents execute bounded work, continue through approved queues, preserve evidence, stop at safety gates, and hand off cleanly.
+
+This protocol is **documentation-only**. It does not add runtime agent-loop behavior, GitHub Actions automation, or tool-specific scripts.
+
+## Purpose
+
+The default workflow for agent-assisted development requires the human operator to prompt every next task:
+
+```
+Human → agent → PR → human → Human → agent → PR → human → ...
+```
+
+The human acts as the loop scheduler. This protocol replaces that pattern with a durable operating protocol stored in the repository:
+
+```
+Human approves an epic goal
+→ agent reads repo protocol
+→ agent executes queued tasks
+→ agent opens PRs or one final epic PR depending on mode
+→ agent stops only for blockers, failed verification, or human review gates
+```
+
+The repository, not the chat, becomes the source of truth.
+
+## Operating modes
+
+Defines two modes:
+
+### Task Mode
+
+One bounded task. Agent stops after:
+
+- task implementation
+- verification
+- PR body / report
+- handoff
+
+Use for:
+
+- high-risk work
+- narrow fixes
+- ambiguous tasks
+- tasks requiring human direction
+
+### Epic Completion Mode
+
+Approved queue of bounded tasks. Agent continues through the queue until:
+
+- queue complete
+- verification fails
+- blocker appears
+- scope expands
+- high-risk escalation appears
+- dependency/security/governance/public API change is needed
+- human review gate is reached
+
+Agent must preserve evidence per task. Human still performs final review and merge. No unattended merges.
+
+## Lifecycle
+
+Every task follows this lifecycle:
+
+```
+INTAKE
+→ CONTEXT_SYNC
+→ PLAN
+→ BRANCH
+→ EXECUTE_TASK
+→ VERIFY
+→ COMMIT
+→ REPORT
+→ CONTINUE_OR_STOP
+→ FINALIZE_PR
+→ HUMAN_REVIEW
+→ MERGE_ONLY_WITH_APPROVAL
+```
+
+For Epic Completion Mode, `CONTINUE_OR_STOP` continues automatically to the next queued bounded task unless a stop condition appears.
+
+## Roles
+
+Defined as responsibilities, not mandatory separate tools:
+
+| Role               | Responsibility                                                   |
+| ------------------ | ---------------------------------------------------------------- |
+| Operator           | Human owner. Approves scope, high-risk changes, and final merge. |
+| Orchestrator Agent | Maintains queue, scope, progress, PR plan, and handoff.          |
+| Worker Agent       | Executes one bounded task at a time.                             |
+| Verification Agent | Runs checks and records exact evidence.                          |
+| Review Agent       | Reviews scope, safety, docs, CI, and product boundary.           |
+| Tool Runtime       | Codex, Claude Code, Cursor, OpenCode, or human terminal.         |
+
+One tool may perform multiple roles, but the worker must not approve its own work.
+
+## Sources of truth
+
+1. GitHub issue / PR / human-approved prompt
+2. `docs/LOOP_ENGINEERING.md`
+3. `specs/loop-engineering/AGENT_PROTOCOL.md`
+4. relevant product docs:
+
+   - `README.md`
+   - `docs/guides/product-surface-inventory.md`
+   - `docs/guides/frontend-alpha-status.md`
+   - `docs/guides/serve-api-status.md`
+   - `docs/research/model-layer-positioning.md`
+   - `docs/research/autonomous-loop-graduation-criteria.md`
+5. current PR body
+6. CI output
+7. handoff/progress file
+
+When sources disagree, stop and report the conflict.
+
+Do not invent intent from chat memory.
+
+## Verification bundles
+
+### Rust/core/docs touching Rust behavior
+
+```bash
+cargo fmt --check
+cargo check
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+### Docs-only
+
+Docs-only PRs may skip frontend checks unless frontend docs or frontend paths are touched.
+
+### Frontend
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+Lint is not required yet unless explicitly scoped (current lint status is a known follow-up).
+
+### API server
+
+```bash
+cargo test api_server_smoke
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+### Local model / Ornith validation
+
+Use the documented manual endpoint path. Do not claim benchmark results unless the validation plan has been completed.
+
+### Autonomous loop
+
+Do not promote. Only work on it under explicit scope and with the autonomous loop graduation criteria open.
+
+## Related files
+
+- [Agent Protocol](specs/loop-engineering/AGENT_PROTOCOL.md) — detailed agent instructions
+- [Safety Gates](specs/loop-engineering/SAFETY_GATES.md) — hard blockers and soft warnings
+- [PR Template](specs/loop-engineering/PR_TEMPLATE.md) — required PR body format
+- [Handoff Template](specs/loop-engineering/HANDOFF_TEMPLATE.md) — handoff report format
+- [Progress Schema](specs/loop-engineering/PROGRESS_SCHEMA.md) — progress tracking format
+- [Task Queue Template](specs/loop-engineering/TASK_QUEUE_TEMPLATE.md) — queue definition format
+- [Comment Templates](specs/loop-engineering/COMMENT_TEMPLATES.md) — standardized issue/PR comments
+
+## See also
+
+- [Product Surface Inventory](guides/product-surface-inventory.md)
+- [Autonomous Loop Graduation Criteria](../research/autonomous-loop-graduation-criteria.md)

--- a/docs/guides/frontend-alpha-status.md
+++ b/docs/guides/frontend-alpha-status.md
@@ -107,6 +107,8 @@ It should not be promoted to stable alpha until at least:
 - [ ] API server compatibility is covered by smoke tests.
 - [ ] README and alpha docs are updated accordingly.
 
+Operational agent workflow is governed by the [Loop Engineering Protocol](../LOOP_ENGINEERING.md).
+
 ## Next recommended PRs
 
 - Add frontend lint/typecheck CI.

--- a/docs/guides/product-surface-inventory.md
+++ b/docs/guides/product-surface-inventory.md
@@ -173,6 +173,8 @@ Every identifiable surface in PrometheOS Lite, classified by maturity.
 | Automatic patch application | future | Listed as explicitly not included |
 | Full autonomous coding | future | Listed as explicitly not included |
 
+Operational agent workflow is governed by the [Loop Engineering Protocol](../LOOP_ENGINEERING.md).
+
 ## Gap analysis
 
 Surfaces that exist in the repo but have no alpha-level documentation or CI:

--- a/docs/guides/serve-api-status.md
+++ b/docs/guides/serve-api-status.md
@@ -116,6 +116,8 @@ Current stable alpha guarantees remain:
 - artifacts are reviewable
 - provenance records whether a model was invoked
 
+Operational agent workflow is governed by the [Loop Engineering Protocol](../LOOP_ENGINEERING.md).
+
 ## Limitations
 
 - Not part of stable alpha golden path.

--- a/docs/research/autonomous-loop-graduation-criteria.md
+++ b/docs/research/autonomous-loop-graduation-criteria.md
@@ -95,6 +95,8 @@ Docs must clearly say what each mode can and cannot do.
 
 No docs may imply "runs while I sleep" until the above criteria are met.
 
+Operational agent workflow is governed by the [Loop Engineering Protocol](../LOOP_ENGINEERING.md).
+
 ## What this does not claim
 
 This document does not claim:

--- a/specs/loop-engineering/AGENT_PROTOCOL.md
+++ b/specs/loop-engineering/AGENT_PROTOCOL.md
@@ -1,0 +1,119 @@
+# Agent Protocol
+
+Defines how agents execute work under the PrometheOS Lite Loop Engineering Protocol.
+
+## Sources of truth (in order)
+
+1. GitHub issue / PR / human-approved prompt
+2. `docs/LOOP_ENGINEERING.md`
+3. `specs/loop-engineering/AGENT_PROTOCOL.md`
+4. relevant product docs:
+
+   - `README.md`
+   - `docs/guides/product-surface-inventory.md`
+   - `docs/guides/frontend-alpha-status.md`
+   - `docs/guides/serve-api-status.md`
+   - `docs/research/model-layer-positioning.md`
+   - `docs/research/autonomous-loop-graduation-criteria.md`
+5. current PR body
+6. CI output
+7. handoff/progress file
+
+When sources disagree, stop and report the conflict. Do not invent intent from chat memory.
+
+## Operating modes
+
+### Task Mode
+
+One bounded task. Agent stops after:
+
+- task implementation
+- verification
+- PR body / report
+- handoff
+
+Use for:
+
+- high-risk work
+- narrow fixes
+- ambiguous tasks
+- tasks requiring human direction
+
+### Epic Completion Mode
+
+Approved queue of bounded tasks. Agent continues through the queue until:
+
+- queue complete
+- verification fails
+- blocker appears
+- scope expands
+- high-risk escalation appears
+- dependency/security/governance/public API change is needed
+- human review gate is reached
+
+Agent must preserve evidence per task. Human still performs final review and merge. No unattended merges.
+
+## Lifecycle
+
+```
+INTAKE
+→ Read approved scope and queue from GitHub issue, PR, or human prompt.
+→ Confirm mode (Task Mode or Epic Completion Mode).
+→ If no queue file exists, create one using TASK_QUEUE_TEMPLATE.md.
+
+CONTEXT_SYNC
+→ Read all source-of-truth documents.
+→ Read current progress file if continuing.
+→ Check CI status on current branch.
+→ Resolve any source-of-truth conflicts or stop.
+
+PLAN
+→ For the current bounded task, produce a short plan.
+→ Confirm the plan does not exceed approved scope.
+
+BRANCH
+→ Create a branch from the latest main.
+→ Branch naming: `{type}/{description}` (e.g., `docs/loop-engineering-protocol`, `feat/frontend-lint-ci`).
+
+EXECUTE_TASK
+→ Implement the bounded task.
+→ Do not make changes outside the approved scope.
+→ Do not add dependencies without escalation.
+→ Do not refactor unrelated code.
+→ Do not change stable alpha behavior.
+
+VERIFY
+→ Run the relevant verification bundle from docs/LOOP_ENGINEERING.md.
+→ Record exact verification output.
+→ Do not claim checks that were not run.
+→ Do not skip or narrow tests only to pass.
+
+COMMIT
+→ Commit atomically: one commit per bounded task where possible.
+→ Write a clear commit message describing what changed and why.
+→ Do not commit secrets, credentials, or API keys.
+
+REPORT
+→ Update progress file with completed task, commit hash, files changed, verification results, and notes.
+→ If using Epic Completion Mode, update the queue.
+
+CONTINUE_OR_STOP
+→ If Task Mode: stop, create PR, write handoff.
+→ If Epic Completion Mode:
+  → If queue is complete: stop, create final PR or epic PR, write handoff.
+  → If stop condition appears: stop, create PR for completed tasks, write handoff with blocker description.
+  → Otherwise: continue to next task (go to CONTEXT_SYNC).
+
+FINALIZE_PR
+→ Use PR_TEMPLATE.md.
+→ Fill in all sections accurately.
+→ Do not claim unrun checks passed.
+→ List known limitations and follow-ups.
+
+HUMAN_REVIEW
+→ Leave PR open for human review.
+→ Do not merge.
+→ Respond to review requests.
+
+MERGE_ONLY_WITH_APPROVAL
+→ Do not merge to main without explicit human approval.

--- a/specs/loop-engineering/COMMENT_TEMPLATES.md
+++ b/specs/loop-engineering/COMMENT_TEMPLATES.md
@@ -1,0 +1,68 @@
+# Comment Templates
+
+Standardized GitHub comment templates for loop-engineering operations.
+
+## Progress update
+
+```
+**Loop Progress Update**
+
+Mode: {Task Mode | Epic Completion Mode}
+Current task: {task name}
+Completed: {N} of {M} tasks
+Blockers: {none or description}
+Verification: {passed / partial / failed}
+Next: {next task or handoff}
+```
+
+## Blocker report
+
+```
+**Blocker — execution stopped**
+
+Stop reason: {blocker description}
+Completed tasks: {list}
+PR: {link if any}
+Handoff: {link to handoff file}
+
+This needs human review before continuing.
+```
+
+## Handoff notification
+
+```
+**Handoff**
+
+Task: {task name}
+Mode: {Task Mode | Epic Completion Mode}
+Status: {completed / blocked / partial}
+Verification: {summary}
+Blockers: {none or description}
+PR: {link if any}
+
+See handoff file for full details.
+```
+
+## Verification failure
+
+```
+**Verification Failed**
+
+Command: {command that failed}
+Exit code: {exit code}
+Output: {relevant output or link}
+
+Task cannot proceed until this is resolved.
+```
+
+## Scope warning
+
+```
+**Scope Warning**
+
+The following change appears to exceed the approved scope:
+
+{description of change}
+
+Proceeding would require explicit approval. Stopping per protocol.
+```

--- a/specs/loop-engineering/HANDOFF_TEMPLATE.md
+++ b/specs/loop-engineering/HANDOFF_TEMPLATE.md
@@ -1,0 +1,49 @@
+# Handoff Template
+
+Use this template when handing off between agents or between tasks.
+
+```markdown
+# Handoff
+
+## Current state
+
+<!-- Brief description of the current state of work. -->
+
+## Completed work
+
+<!-- What was implemented, changed, or delivered. -->
+
+## Verification run
+
+<!-- Exact commands run and their exit codes / key output. -->
+
+## What was not run
+
+<!-- Verification steps that were intentionally or unavoidably skipped. -->
+
+## Blockers
+
+<!-- Any blockers encountered. None if no blockers. -->
+
+## Risks
+
+<!-- Any risks, concerns, or areas that need human attention. -->
+
+## Next task
+
+<!-- The next task in the queue, if applicable. -->
+
+## Stop reason
+
+<!-- Why execution stopped: queue complete, verification failed, blocker, scope expansion, etc. -->
+
+## Confidence
+
+<!--
+High / Medium / Low
+
+High: all checks pass, scope is contained, docs accurate.
+Medium: minor concern (e.g., partial verification, manual demo not run).
+Low: significant concern that needs human review before proceeding.
+-->
+```

--- a/specs/loop-engineering/PROGRESS_SCHEMA.md
+++ b/specs/loop-engineering/PROGRESS_SCHEMA.md
@@ -1,0 +1,63 @@
+# Progress Schema
+
+Progress tracking format for loop-engineering tasks.
+
+```markdown
+# Loop Progress
+
+## Mode
+
+<!-- Task Mode or Epic Completion Mode. -->
+
+## Approved scope
+
+<!-- Link or description of the approved epic or task. -->
+
+## Current queue
+
+- [ ] Task 1 <!-- Brief description -->
+- [ ] Task 2 <!-- Brief description -->
+- [ ] Task 3 <!-- Brief description -->
+
+## Completed tasks
+
+| Task | Commit | Files | Verification | Notes |
+|---|---|---|---|---|
+| <!-- Task name --> | <!-- Commit hash --> | <!-- Files changed --> | <!-- Verif. results --> | <!-- Notes --> |
+
+## Current task
+
+<!-- What is being worked on now. -->
+
+## Blockers
+
+<!-- Any blockers. None if no blockers. -->
+
+## Verification evidence
+
+<!-- Summary of verification results for the current or most recent task. -->
+
+## Stop / continue decision
+
+<!--
+For Epic Completion Mode:
+- Continue to next task
+- Stop: queue complete
+- Stop: verification failed
+- Stop: blocker appeared
+- Stop: scope expansion detected
+- Stop: high-risk escalation
+- Stop: human review gate reached
+-->
+
+## Next recommended action
+
+<!-- What the next agent or human should do. -->
+```
+
+## Usage
+
+- Create this file at the start of an Epic Completion Mode run.
+- Update after each completed task.
+- Include in the handoff report when stopping.
+- Archive to `handoff.md` at the repository root when the epic is complete.

--- a/specs/loop-engineering/PR_TEMPLATE.md
+++ b/specs/loop-engineering/PR_TEMPLATE.md
@@ -1,0 +1,60 @@
+# PR Template
+
+Use this template for all loop-engineering PRs.
+
+```markdown
+## Summary
+
+<!-- Concise description of what this PR does and why. -->
+
+## Mode
+
+<!-- Task Mode or Epic Completion Mode. -->
+
+## Approved scope
+
+<!-- Link to the approved issue, comment, or prompt that authorized this work. -->
+
+## Tasks completed
+
+<!-- List of completed bounded tasks. -->
+
+## Files changed
+
+<!-- List of files changed with brief reason for each. -->
+
+## Safety boundary
+
+<!--
+Confirm no stable alpha changes, no autonomous execution promotion,
+no dependency additions, no API/runtime behavior changes outside scope.
+-->
+
+## Verification
+
+<!--
+Checklist of verification steps run and their results.
+Do not claim checks that were not run.
+-->
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo check`
+- [ ] `cargo test`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cd frontend && npm ci && npm run build` (if frontend touched)
+
+## Known limitations
+
+<!-- Any known limitations, soft warnings, or partial coverage. -->
+
+## Follow-ups
+
+<!-- Tasks for future PRs, if any. -->
+
+## Human review gate
+
+<!--
+Leave this section for the human reviewer.
+This PR requires human approval before merge.
+-->
+```

--- a/specs/loop-engineering/README.md
+++ b/specs/loop-engineering/README.md
@@ -1,0 +1,33 @@
+# Loop Engineering — Specs Index
+
+This directory contains the specification files for the PrometheOS Lite Loop Engineering Protocol.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `AGENT_PROTOCOL.md` | Detailed agent protocol with lifecycle, roles, and operating modes |
+| `SAFETY_GATES.md` | Hard blockers and soft warnings specific to PrometheOS Lite |
+| `PR_TEMPLATE.md` | Required PR body format for loop-engineering PRs |
+| `HANDOFF_TEMPLATE.md` | Handoff report format for agent transitions |
+| `PROGRESS_SCHEMA.md` | Progress tracking schema for Epic Completion Mode |
+| `TASK_QUEUE_TEMPLATE.md` | Queue definition format for approved task sequences |
+| `COMMENT_TEMPLATES.md` | Standardized GitHub comment templates for loop operations |
+
+## How to use
+
+1. Read `AGENT_PROTOCOL.md` first — it defines the operating modes and lifecycle.
+2. Consult `SAFETY_GATES.md` for stop conditions.
+3. Use `TASK_QUEUE_TEMPLATE.md` to define approved queues.
+4. Track progress using the schema in `PROGRESS_SCHEMA.md`.
+5. Use `PR_TEMPLATE.md` when opening PRs.
+6. Use `HANDOFF_TEMPLATE.md` when handing off between agents or tasks.
+7. Use `COMMENT_TEMPLATES.md` for standardized issue/PR communication.
+
+## Design principles
+
+- Spec-driven delivery: the repository is the source of truth.
+- Visible evidence: every task produces artifacts and verification results.
+- Hard safety boundaries: stop rules prevent scope creep and CI weakening.
+- Human final approval: no unattended merges.
+- Tool-agnostic: no requirement for a specific coding agent or platform.

--- a/specs/loop-engineering/SAFETY_GATES.md
+++ b/specs/loop-engineering/SAFETY_GATES.md
@@ -1,0 +1,70 @@
+# Safety Gates
+
+Hard blockers and soft warnings for the PrometheOS Lite Loop Engineering Protocol.
+
+## Hard blockers
+
+Stop immediately and hand off if any of these appear:
+
+- **CI weakened** — CI is weakened, tests are removed, skipped, or narrowed only to pass.
+- **Stable alpha scope change** — Stable alpha scope changes without explicit approval.
+- **`prometheos work` behavior change** — `prometheos work` behavior changes outside approved scope.
+- **Source modification in stable alpha** — Source-modifying behavior is added to the stable alpha path.
+- **Autonomous execution promoted** — Autonomous execution loop is promoted or implied stable.
+- **Benchmark claims without validation** — Benchmark claims are added without completed validation evidence.
+- **Ornith/local model false claim** — Ornith/local model support is claimed automatic without validation.
+- **Frontend promoted** — Frontend is promoted to stable alpha.
+- **API server promoted** — API server is promoted to stable alpha.
+- **New dependency** — New dependency is added without explicit review.
+- **Public API, governance, release docs, or ADRs changed outside scope** — Public API, governance docs, release docs, or ADRs change outside scope.
+- **Secrets exposed** — Secrets, credentials, API keys, or private tokens are exposed.
+- **Large unrelated refactor** — Large unrelated refactor appears outside approved scope.
+- **Cannot separate changes** — The agent cannot separate task changes from unrelated local changes.
+- **Unattended merge** — Merge to main would happen without human approval.
+
+## Soft warnings
+
+Soft warnings must be visible in the PR body or handoff report. They do not stop execution but must be documented:
+
+- **Docs drift** — docs drift from current code.
+- **Partial verification** — verification is partial (not all checks run).
+- **Local service unavailable** — local service (API server, frontend) unavailable for manual demo.
+- **Manual demo not run** — manual demo was not executed.
+- **Lint not enforced** — lint is not enforced (known follow-up for frontend).
+- **E2E not available** — E2E coverage is not available.
+- **Frontend/API compatibility not fully covered** — frontend/API compatibility is not fully covered by tests.
+
+## Product boundary reference
+
+### Stable alpha
+
+- `prometheos work` — Repo Workbench CRUD, artifacts, memory, continue, approve
+- deterministic static analysis (tree-sitter, no model required)
+- WorkContext creation, run, continuation
+- risk report and suggested patch plan artifacts
+- approval recording
+- artifact provenance
+- provider routing
+- LLM client (OpenAI-compatible)
+- provider configuration
+- mock provider integration tests
+- Linux install smoke CI
+- golden path CI
+
+### Experimental
+
+- `prometheos serve` API server
+- frontend
+- harness execution loop
+- model-backed provider paths
+- local model / Ornith validation
+- autonomous execution loop
+
+### Future (not alpha)
+
+- Brain
+- Mnemosyne integration
+- cloud/team control plane
+- plugin marketplace
+- benchmark claims
+- autonomous coding claims

--- a/specs/loop-engineering/TASK_QUEUE_TEMPLATE.md
+++ b/specs/loop-engineering/TASK_QUEUE_TEMPLATE.md
@@ -1,0 +1,49 @@
+# Task Queue Template
+
+Use this template to define an approved queue of bounded tasks for Epic Completion Mode.
+
+```markdown
+# Epic Queue
+
+## Epic
+
+<!-- Short name for the epic. -->
+
+## Mode
+
+Epic Completion Mode
+
+## Approved scope
+
+<!-- Description of the approved scope boundary. -->
+
+## Queue
+
+1. **Task 1** — <!-- Brief description -->
+   - Scope: <!-- What is included -->
+   - Boundaries: <!-- What is excluded -->
+   - Verification: <!-- Which verification bundle to run -->
+
+2. **Task 2** — <!-- Brief description -->
+   - Scope:
+   - Boundaries:
+   - Verification:
+
+3. **Task 3** — <!-- Brief description -->
+   - Scope:
+   - Boundaries:
+   - Verification:
+
+## Stop conditions
+
+- Stop if any hard blocker from SAFETY_GATES.md appears.
+- Stop if scope expands beyond the approved queue.
+- Stop if a task verification fails.
+- Stop if a dependency change is needed.
+- Stop if public API or governance changes are needed.
+- Stop at human review gate.
+
+## Human approval
+
+<!-- Required before merge. -->
+```


### PR DESCRIPTION
## Summary

Adds a repository-native Loop Engineering Protocol for PrometheOS Lite.

The protocol defines how agents should execute bounded work, continue through approved queues, preserve evidence, stop at safety gates, and hand off cleanly.

## What changed

- Added `docs/LOOP_ENGINEERING.md`.
- Added `specs/loop-engineering/AGENT_PROTOCOL.md`.
- Added safety gates, PR template, handoff template, and progress schema.
- Defined Task Mode and Epic Completion Mode.
- Added PrometheOS Lite-specific stop rules and verification bundles.
- Linked the protocol from README and relevant docs.

## Status

This is a documentation/protocol PR.

It does not add runtime agent-loop behavior.

It does not promote autonomous execution.

It does not change stable alpha scope.

## Safety model

Docs-only PR.

No Rust runtime behavior changed.

No API behavior changed.

No frontend behavior changed.

No provider/model calls added.

No source-modifying behavior changed.

No autonomous execution behavior changed.

No unattended merge behavior added.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd frontend && npm ci && npm run build`

## Follow-ups

- Add optional loop structure validator.
- Add GitHub label set for loop PRs.
- Add a first approved Epic Completion Mode queue.
- Use the protocol for the next multi-PR frontend/API hardening sequence.
