### PR TITLE
docs: add PrometheOS agent instructions and ReviewOnly automation plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# PrometheOS Lite — Agent Instructions
+
+This is the first file every coding agent should read before working in this repository.
+
+PrometheOS Lite follows the Loop Engineering Protocol.
+
+## Required reading
+
+Before modifying the repository, read:
+
+- [Loop Engineering Protocol](docs/LOOP_ENGINEERING.md)
+- [Agent Protocol](specs/loop-engineering/AGENT_PROTOCOL.md)
+- [Safety Gates](specs/loop-engineering/SAFETY_GATES.md)
+- [Product Surface Inventory](docs/guides/product-surface-inventory.md)
+- [Model-layer positioning](docs/research/model-layer-positioning.md)
+- [Autonomous loop graduation criteria](docs/research/autonomous-loop-graduation-criteria.md)
+
+## Product boundaries
+
+```
+Stable alpha:
+- prometheos work
+
+Experimental:
+- prometheos serve
+- frontend
+- API server
+- local model / Ornith validation
+- harness execution loop
+- autonomous execution loop
+
+Future / not alpha:
+- Brain
+- Mnemosyne integration
+- cloud/team control plane
+- plugin marketplace
+- benchmark claims
+- autonomous coding claims
+```
+
+## Rules
+
+- No unattended merges.
+- No CI weakening.
+- No dependency changes without explicit approval.
+- No benchmark claims without completed validation evidence.
+- No automatic Ornith/local model support claims unless validated.
+- No frontend promotion.
+- No API server promotion.
+- No autonomous execution promotion.
+- No Brain/Mnemosyne/cloud/plugin claims.
+- No unrelated refactors.
+- One concern per PR.
+- Prefer small PRs.
+- Record exact verification evidence.
+- Do not claim unrun checks passed.
+- Update progress/handoff files when working under an active queue.
+
+## Minimality budget
+
+Default PR budget:
+- Prefer 5 files or fewer.
+- Prefer 200 net changed lines or fewer.
+- Prefer one bounded task per PR.
+- Escalate before exceeding the budget.
+
+These are defaults, not hard limits. Some docs/planning PRs may exceed them with explicit scope.
+
+## Verification expectations
+
+Rust baseline:
+```bash
+cargo fmt --check
+cargo check
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Frontend baseline:
+```bash
+cd frontend
+npm ci
+npm run lint
+npm run build
+```
+
+Frontend checks are required when frontend files, frontend docs, frontend CI, or frontend-related queue files are touched.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ PrometheOS Lite is not yet:
 - [Model-layer positioning](docs/research/model-layer-positioning.md)
 - [Autonomous loop graduation criteria](docs/research/autonomous-loop-graduation-criteria.md)
 - Architecture audit: [Provider architecture audit](docs/research/provider-architecture-audit.md)
+- [Agent instructions](AGENTS.md) — root instructions for coding agents working in this repo
+- [PrometheOS ReviewOnly GitHub flow](docs/guides/prometheos-reviewonly-github-flow.md) — planned read-only PR review automation
 - [Loop Engineering Protocol](docs/LOOP_ENGINEERING.md) — operating protocol for agent-assisted development
 - [Alpha release notes](docs/release/v1.6.1-alpha.1.md)
 

--- a/docs/LOOP_ENGINEERING.md
+++ b/docs/LOOP_ENGINEERING.md
@@ -178,6 +178,14 @@ The first active queue is:
 
 * [Frontend/API Experimental Surface Hardening](../specs/active/frontend-api-hardening/QUEUE.md)
 
+## Agent instructions and automation levels
+
+Coding agents should read [AGENTS.md](../AGENTS.md) before modifying the repository.
+
+GitHub automation levels are defined in [GitHub Automation Levels](../specs/loop-engineering/GITHUB_AUTOMATION_LEVELS.md).
+
+Agent budgets are defined in [Agent Budgets](../specs/loop-engineering/AGENT_BUDGETS.md).
+
 ## See also
 
 - [Product Surface Inventory](guides/product-surface-inventory.md)

--- a/docs/guides/prometheos-reviewonly-github-flow.md
+++ b/docs/guides/prometheos-reviewonly-github-flow.md
@@ -1,0 +1,105 @@
+# PrometheOS ReviewOnly — Planned GitHub Automation Flow
+
+This document describes the future ReviewOnly GitHub automation flow.
+
+ReviewOnly is the PrometheOS-native equivalent of Claude Code's automatic PR review mode. It provides read-only diff review via a GitHub Action that posts structured review comments.
+
+This is a **planned design**. No automation has been implemented yet.
+
+## Level 1: ReviewOnly
+
+| Property       | Value                                    |
+|----------------|------------------------------------------|
+| Trigger        | `pull_request` opened/synchronize        |
+| Permissions    | read-only diff review, comments only     |
+| Writes         | review comments only                     |
+| No commits     | yes                                      |
+| No branch writes | yes                                    |
+| No merge       | yes                                      |
+| No issue-to-PR | yes                                      |
+| No dependency changes | yes                              |
+| No code modification | yes                              |
+
+## Reviewer behavior
+
+When triggered, the reviewer should:
+
+1. Read `AGENTS.md`.
+2. Read Loop Engineering Protocol.
+3. Read Safety Gates.
+4. Inspect PR diff.
+5. Check product boundary risks.
+6. Check verification evidence.
+7. Check if PR exceeds budget.
+8. Check if docs overclaim maturity.
+9. Check if frontend/API/autonomous surfaces are promoted accidentally.
+10. Post findings grouped by severity.
+
+## Finding severities
+
+| Severity    | Meaning                                      |
+|-------------|----------------------------------------------|
+| Blocker     | Must be resolved before merge                |
+| Warning     | Should be reviewed and addressed             |
+| Suggestion  | Optional improvement                         |
+| Question    | Clarification needed                         |
+
+## Confidence labels
+
+| Label             | Meaning                                      |
+|-------------------|----------------------------------------------|
+| High confidence   | Clear violation of protocol or safety gate   |
+| Medium confidence | Likely issue, may need human interpretation  |
+| Low confidence    | Possible issue, needs human review           |
+
+## ReviewOnly output format
+
+```markdown
+## PrometheOS ReviewOnly Report
+
+Mode: ReviewOnly
+
+Scope:
+- Files reviewed:
+- Lines changed:
+- Budget status:
+
+Findings:
+- Blockers:
+- Warnings:
+- Suggestions:
+- Questions:
+
+Verification evidence:
+- Claimed checks:
+- Missing checks:
+- CI status:
+
+Product boundary check:
+- Stable alpha:
+- Experimental surfaces:
+- Overclaim risk:
+
+Recommendation:
+- Approve after human review
+- Request changes
+- Wait for CI
+- Needs scope clarification
+```
+
+## Stop conditions
+
+The reviewer should stop and flag if any of the following apply:
+
+- Diff too large.
+- Source-of-truth conflict.
+- Missing verification for changed area.
+- Possible CI weakening.
+- Possible stable alpha scope change.
+- Possible frontend/API/autonomous promotion.
+- Dependency changes without approval.
+- Secrets or credentials.
+
+## Human review
+
+ReviewOnly does not replace human review. All PRs still require human approval before merge.

--- a/specs/loop-engineering/AGENT_BUDGETS.md
+++ b/specs/loop-engineering/AGENT_BUDGETS.md
@@ -1,0 +1,51 @@
+# Agent Budgets and Path Controls
+
+This spec defines the default budgets and path controls that coding agents must follow when working in this repository.
+
+## Default file budget
+
+- Prefer **5 files or fewer** per PR.
+
+## Default line budget
+
+- Prefer **200 net changed lines or fewer** per PR.
+
+## Large-change escalation
+
+If a PR exceeds either budget:
+
+1. Explain why the change exceeds budget.
+2. Confirm the change is within approved scope.
+3. Split into smaller PRs when possible.
+
+## Path allowlist
+
+Agents should only touch paths required by the approved task.
+
+## Path risk levels
+
+| Risk level | Paths                                               |
+|------------|------------------------------------------------------|
+| low        | docs, specs, comments                                |
+| medium     | CI configs, tests, frontend docs, scripts            |
+| high       | runtime Rust behavior, provider/model paths, API semantics, autonomous execution, release/governance docs |
+
+## Dependency budget
+
+- Default: **no new dependencies**.
+- Any dependency change requires explicit approval.
+
+## Verification budget
+
+- Verification must match the surfaces touched.
+- Must not claim skipped checks passed.
+
+## Stop conditions
+
+Agents must stop and escalate when:
+
+- Budget exceeded without approval.
+- Dependency required.
+- Public API change required.
+- Product boundary unclear.
+- Verification too expensive or unavailable.

--- a/specs/loop-engineering/GITHUB_AUTOMATION_LEVELS.md
+++ b/specs/loop-engineering/GITHUB_AUTOMATION_LEVELS.md
@@ -28,7 +28,7 @@ GitHub PR automation reviews diffs and posts comments.
 - No merges.
 - No issue-to-PR.
 
-See [ReviewOnly GitHub flow](../guides/prometheos-reviewonly-github-flow.md) for detailed behavior.
+See [ReviewOnly GitHub flow](../../docs/guides/prometheos-reviewonly-github-flow.md) for detailed behavior.
 
 ## Level 2 — Assisted Draft PR
 
@@ -56,4 +56,4 @@ PrometheOS can run from a self-hosted GitHub runner or local machine.
 
 **Blocked.** Only allowed after autonomous-loop graduation criteria are met.
 
-See [Autonomous loop graduation criteria](../research/autonomous-loop-graduation-criteria.md).
+See [Autonomous loop graduation criteria](../../docs/research/autonomous-loop-graduation-criteria.md).

--- a/specs/loop-engineering/GITHUB_AUTOMATION_LEVELS.md
+++ b/specs/loop-engineering/GITHUB_AUTOMATION_LEVELS.md
@@ -1,0 +1,59 @@
+# GitHub Automation Levels
+
+This spec defines the automation ladder for PrometheOS Lite. Each level increases the degree of automation while maintaining safety gates and human oversight.
+
+| Level | Name              | Description                                      |
+|-------|-------------------|--------------------------------------------------|
+| 0     | Manual Queue      | Human invokes the coding agent manually           |
+| 1     | ReviewOnly        | Read-only PR diff review with structured comments |
+| 2     | Assisted Draft PR | Agent creates draft PRs from approved issues      |
+| 3     | Epic Completion   | Agent executes approved queues with progress tracking |
+| 4     | Self-hosted Runner| PrometheOS runs via self-hosted runner           |
+| 5     | Autonomous Patch  | Blocked — requires graduated autonomy approval   |
+
+## Level 0 — Manual Queue
+
+Human invokes the coding agent manually with an approved queue.
+
+No GitHub automation.
+
+This is the current state after PR #64.
+
+## Level 1 — ReviewOnly
+
+GitHub PR automation reviews diffs and posts comments.
+
+- No commits.
+- No branch writes.
+- No merges.
+- No issue-to-PR.
+
+See [ReviewOnly GitHub flow](../guides/prometheos-reviewonly-github-flow.md) for detailed behavior.
+
+## Level 2 — Assisted Draft PR
+
+A label or explicit human command can ask an agent to create a draft PR from an approved issue.
+
+- No merge.
+- No dependency changes without approval.
+- No runtime promotion.
+
+## Level 3 — Epic Completion
+
+Agent can execute an approved queue, updating progress and handoff files.
+
+- Still no merge.
+- Stops at safety gates.
+
+## Level 4 — Self-hosted Runner
+
+PrometheOS can run from a self-hosted GitHub runner or local machine.
+
+- Must still obey all protocol gates.
+- Must use path filters and budgets.
+
+## Level 5 — Autonomous Patch
+
+**Blocked.** Only allowed after autonomous-loop graduation criteria are met.
+
+See [Autonomous loop graduation criteria](../research/autonomous-loop-graduation-criteria.md).

--- a/specs/loop-engineering/README.md
+++ b/specs/loop-engineering/README.md
@@ -7,12 +7,16 @@ This directory contains the specification files for the PrometheOS Lite Loop Eng
 | File | Purpose |
 |---|---|
 | `AGENT_PROTOCOL.md` | Detailed agent protocol with lifecycle, roles, and operating modes |
+| `AGENT_BUDGETS.md` | Default budgets, path controls, and escalation rules |
+| `GITHUB_AUTOMATION_LEVELS.md` | Automation ladder from manual queue to autonomous patch |
 | `SAFETY_GATES.md` | Hard blockers and soft warnings specific to PrometheOS Lite |
 | `PR_TEMPLATE.md` | Required PR body format for loop-engineering PRs |
 | `HANDOFF_TEMPLATE.md` | Handoff report format for agent transitions |
 | `PROGRESS_SCHEMA.md` | Progress tracking schema for Epic Completion Mode |
 | `TASK_QUEUE_TEMPLATE.md` | Queue definition format for approved task sequences |
 | `COMMENT_TEMPLATES.md` | Standardized GitHub comment templates for loop operations |
+
+The root instruction file is [AGENTS.md](../../AGENTS.md) — coding agents should read it before working in this repository.
 
 ## How to use
 


### PR DESCRIPTION
## Summary

Adds root PrometheOS agent instructions and documents the planned ReviewOnly GitHub automation flow.

This PR defines how coding agents should work in this repository before any GitHub automation is implemented.

## What changed

- Added \AGENTS.md\.
- Added \docs/guides/prometheos-reviewonly-github-flow.md\.
- Added \specs/loop-engineering/AGENT_BUDGETS.md\.
- Added \specs/loop-engineering/GITHUB_AUTOMATION_LEVELS.md\.
- Linked the new docs from README and Loop Engineering docs.

## Mode

Task Mode.

## Safety boundary

Docs/specs only.

No runtime behavior changed.

No GitHub Actions workflow added.

No automation implemented.

No dependencies added.

No Claude/Anthropic integration added.

No frontend source code changed.

No API behavior changed.

No autonomous execution behavior changed.

Stable alpha remains \prometheos work\.

Frontend remains experimental.

API server remains experimental.

Autonomous execution remains experimental.

## Verification

- [x] \cargo fmt --check\
- [x] \cargo check\
- [x] \cargo test\
- [x] \cargo clippy --all-targets --all-features -- -D warnings\
- [x] \cd frontend && npm ci\
- [x] \cd frontend && npm run lint\
- [x] \cd frontend && npm run build\

## Known limitations

This PR documents the ReviewOnly flow but does not implement it.

Future PRs may add a read-only GitHub Action or self-hosted runner integration.

## Follow-ups

- Add optional ReviewOnly GitHub Action.
- Add optional loop structure validator.
- Add frontend/API smoke implementation queue.