### PR TITLE
specs: add Phase 2 full-stack compatibility smoke queue (#69)

### DIFF
--- a/specs/active/phase2-fullstack-compat-smoke/HANDOFF.md
+++ b/specs/active/phase2-fullstack-compat-smoke/HANDOFF.md
@@ -1,0 +1,63 @@
+# Phase 2 Full-Stack Compatibility Smoke Handoff
+
+## Current state
+
+Queue defined, not executed. This PR (`#69`) registers the Phase 2 full-stack compatibility smoke queue under `specs/active/phase2-fullstack-compat-smoke/`. Execution is a separate Epic Completion run to be approved after merge.
+
+## Completed work
+
+### Queue definition (this PR)
+
+- Created `specs/active/phase2-fullstack-compat-smoke/QUEUE.md` defining three tasks:
+  - Task 1 — Full-stack smoke script (build binary, start `prometheos serve`, `curl` health + project CRUD, teardown).
+  - Task 2 — CI integration for the full-stack smoke (separate job after the Rust build).
+  - Task 3 — Queue handoff and next-loop recommendation.
+- Created `PROGRESS.md` and this `HANDOFF.md`.
+
+**Files:** `specs/active/phase2-fullstack-compat-smoke/QUEUE.md`, `PROGRESS.md`, `HANDOFF.md`
+
+## Verification run
+
+Docs-only change. No Rust or frontend behavior changed, so no `cargo` / `npm` build was required by `docs/LOOP_ENGINEERING.md` (docs-only rule).
+
+Cross-checked the queue scope against source-of-truth docs:
+
+| Queue claim | Source match |
+|---|---|
+| Phase 2 builds binary, starts `prometheos serve`, curls frontend-reachable routes | `frontend-api-compatibility-plan.md` Phase 2 section |
+| Routes verified: health + project CRUD | matches Phase 1 routes in `tests/api_frontend_compatibility.rs` and compatibility plan Step 1–2 |
+| No Playwright / no new deps / no frontend source change | matches `frontend-smoke-strategy.md` (Level 4 excluded) and plan "what this does NOT do" |
+| API server / frontend remain experimental | `docs/guides/product-surface-inventory.md` (serve = experimental, frontend = experimental) |
+
+## What was not run
+
+- Task 1–3 were not executed; this PR defines the queue only.
+- No `cargo build` / `prometheos serve` / `curl` smoke was run.
+- No `npm` / frontend build was run.
+- No CI job was added (that is Task 2 of the execution run).
+
+## Blockers
+
+None encountered.
+
+## Risks
+
+- Low. This is a planning PR. The main execution risk (flagged in Task 1 stop conditions) is that `prometheos serve` startup in CI may need specific config or a writable DB path; the execution queue must report that as a real finding rather than masking it. This is noted in the queue, not resolved here.
+
+## Next queue recommendation
+
+After merge, execute the queue under Epic Completion Mode:
+
+- **Primary:** Task 1 (full-stack smoke script) → Task 2 (CI job) → Task 3 (handoff).
+- Secondary candidates for a later queue (not part of this one):
+  - **Level 3 API connectivity smoke** — verify the frontend can reach the API server (separate from Phase 2 route smoke; see `frontend-smoke-strategy.md` Level 3).
+  - **ReviewOnly GitHub Action implementation** — the read-only PR review Action (Level 1 of the automation ladder), now that `AGENTS.md` house rules exist.
+  - **Loop structure validator** — validate `QUEUE.md` / `PROGRESS.md` / `HANDOFF.md` structure.
+
+## Stop reason
+
+Queue defined, not executed. Handoff documents the definition only; execution is a separate approved run.
+
+## Confidence
+
+High. Scope contained, no boundary violations, no dependencies, no behavior changed, and queue scope matches the compatibility plan Phase 2 and smoke strategy.

--- a/specs/active/phase2-fullstack-compat-smoke/PROGRESS.md
+++ b/specs/active/phase2-fullstack-compat-smoke/PROGRESS.md
@@ -1,0 +1,58 @@
+# Phase 2 Full-Stack Compatibility Smoke Progress
+
+## Mode
+
+Epic Completion Mode
+
+## Status
+
+Queue defined. Not yet executed. This PR defines the queue; execution is a separate approved run.
+
+## Approved scope
+
+See `QUEUE.md`.
+
+## Current queue
+
+- [ ] Task 1 — Full-stack smoke script
+- [ ] Task 2 — CI integration for full-stack smoke
+- [ ] Task 3 — Queue handoff and next-loop recommendation
+
+## Completed tasks
+
+| Task | Commit | Files | Verification | Notes |
+|---|---|---|---|---|
+| Queue definition | (this PR) | `QUEUE.md`, `PROGRESS.md`, `HANDOFF.md` | docs-only | Phase 2 full-stack compatibility smoke queue defined, not executed |
+
+## Current task
+
+None. Queue defined, awaiting execution approval.
+
+## Blockers
+
+None.
+
+## Scope notes
+
+This is a planning/queue-definition PR only. It adds no runtime behavior, no dependencies, and does not touch `OVERVIEW.md`, `README.md`, `AGENTS.md`, or any source file. It defines the Phase 2 follow-on to #67 (Phase 1 project CRUD integration tests) and the `frontend-api-compatibility-plan.md` Phase 2 section.
+
+## Verification evidence
+
+Docs-only. No `cargo` / `npm` commands required; no Rust or frontend behavior changed.
+
+Cross-checked the queue scope against source-of-truth docs:
+
+| Queue claim | Source match |
+|---|---|
+| Phase 2 builds binary, starts `prometheos serve`, curls frontend-reachable routes | `frontend-api-compatibility-plan.md` Phase 2 section |
+| Routes verified: health + project CRUD | matches Phase 1 routes in `tests/api_frontend_compatibility.rs` and compatibility plan Step 1–2 |
+| No Playwright / no new deps / no frontend source change | matches `frontend-smoke-strategy.md` (Level 4 excluded) and plan "what this does NOT do" |
+| API server / frontend remain experimental | `docs/guides/product-surface-inventory.md` (serve = experimental, frontend = experimental) |
+
+## Stop / continue decision
+
+Stop. Queue defined. Execution is a separate Epic Completion run to be approved after merge.
+
+## Next recommended action
+
+Merge this PR to register the queue. Then execute under Epic Completion Mode in a follow-up PR (head into Task 1).

--- a/specs/active/phase2-fullstack-compat-smoke/QUEUE.md
+++ b/specs/active/phase2-fullstack-compat-smoke/QUEUE.md
@@ -1,0 +1,175 @@
+# Phase 2 Full-Stack Compatibility Smoke Queue
+
+## Epic
+
+Phase 2 Full-Stack Compatibility Smoke
+
+## Mode
+
+Epic Completion Mode
+
+## Status
+
+Approved queue, not yet executed.
+
+## Owner
+
+Operator: Diego Rhoger
+
+## Purpose
+
+This queue defines the next bounded work item for hardening the experimental frontend/API surfaces without promoting them to stable alpha: a full-stack compatibility smoke.
+
+Phase 1 (implemented in #67) added Rust integration tests for project CRUD against the in-memory router. Phase 2 exercises the same frontend-reachable CRUD cycle the way a real deployment would: build the Rust binary, start `prometheos serve`, and verify the routes over HTTP with `curl`. This catches wiring breakage that in-memory router tests cannot (binary build, server bootstrap, config, port binding, route registration through the real server).
+
+This queue is the definition only. Execution is a separate Epic Completion run approved after this PR merges.
+
+## Source of truth
+
+Agents must read these before executing this queue:
+
+- `AGENTS.md`
+- `docs/LOOP_ENGINEERING.md`
+- `specs/loop-engineering/AGENT_PROTOCOL.md`
+- `specs/loop-engineering/SAFETY_GATES.md`
+- `specs/loop-engineering/AGENT_BUDGETS.md`
+- `specs/loop-engineering/PR_TEMPLATE.md`
+- `specs/loop-engineering/HANDOFF_TEMPLATE.md`
+- `docs/guides/frontend-api-compatibility-plan.md` (Phase 2 section)
+- `docs/guides/frontend-smoke-strategy.md` (Level 3 section)
+- `docs/guides/product-surface-inventory.md`
+- `docs/guides/serve-api-status.md`
+
+## Approved scope
+
+Allowed:
+
+- a shell-based full-stack smoke script that builds the Rust binary, starts `prometheos serve`, verifies frontend-reachable routes over HTTP with `curl`, and tears the server down
+- narrow CI additions to run the full-stack smoke after the Rust build, when proven locally
+- documentation updates related to the smoke implementation
+- progress/handoff updates for this queue
+
+Not allowed:
+
+- promoting frontend to stable alpha
+- promoting API server to stable alpha
+- changing stable alpha scope
+- changing `prometheos work` behavior
+- adding autonomous execution behavior
+- modifying harness autonomous execution
+- adding model/provider behavior
+- adding Brain or Mnemosyne integration
+- adding Playwright or browser automation (Level 4)
+- adding production deployment claims
+- adding dependencies without explicit review
+- weakening CI
+- skipping or narrowing tests only to pass
+- changing API semantics
+
+## Queue
+
+### Task 1 — Full-stack smoke script
+
+Scope:
+
+- Implement Phase 2 of the compatibility plan: a shell script (POSIX `sh` or bash) that:
+  1. builds the Rust binary (`cargo build --bin prometheos-lite` or equivalent),
+  2. starts `prometheos serve` in the background on a known port,
+  3. waits for readiness (poll `GET /health` until 200),
+  4. verifies the frontend-reachable routes over HTTP with `curl`: at minimum `GET /health` and the project CRUD cycle (`POST /projects` → `GET /projects` → `GET /projects/:id`) matching what Phase 1 already covers in-memory,
+  5. tears the server down and exits non-zero on any failure.
+- Reuse the safe endpoints and route shapes already covered by Phase 1 (`tests/api_frontend_compatibility.rs`) so the script and in-memory tests assert the same contract.
+- Use only `curl`, `cargo`, and shell built-ins. No new dependencies.
+
+Boundaries:
+
+- Do not add npm test dependencies.
+- Do not add Playwright or browser automation.
+- Do not change API semantics or route shapes.
+- Do not change frontend source code.
+- Do not promote the API server or frontend.
+- Do not add model/flow execution to the smoke.
+
+Verification:
+
+- `cargo fmt --check`
+- `cargo check`
+- `cargo test`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- run the smoke script locally and confirm it builds, starts the server, passes the curls, and tears down
+- frontend checks only if frontend docs or paths are touched
+
+Stop if:
+
+- `prometheos serve` cannot be started in the local/CI environment for environmental reasons unrelated to the script
+- the binary build or server bootstrap requires config changes outside the smoke script's responsibility
+- verification reveals the server does not expose the Phase 1 routes as expected (treat as a real finding, report it, do not mask)
+
+### Task 2 — CI integration for full-stack smoke
+
+Scope:
+
+- Add a CI job/step that runs the full-stack smoke script after the Rust build.
+- The job builds the binary, runs the script, and fails the build on non-zero exit.
+- Keep it in a separate job from the unit/test matrix so a full-stack environment issue does not block the core Rust checks.
+
+Boundaries:
+
+- Do not weaken existing CI.
+- Do not add dependencies to the workflow beyond what already exists.
+- Do not promote surfaces.
+
+Verification:
+
+- `cargo test` still green
+- the new CI job passes locally-equivalent run if runnable locally, otherwise verified in CI only (document as partial verification in handoff)
+- Rust baseline
+
+Stop if:
+
+- CI changes conflict with existing workflow structure
+- the job cannot run in the current CI runner environment
+- the job would require secrets or external services
+
+### Task 3 — Queue handoff and next-loop recommendation
+
+Scope:
+
+- Update `PROGRESS.md`.
+- Write final handoff.
+- Recommend whether the next queue should focus on:
+  - Level 3 API connectivity smoke (frontend reaches API server)
+  - ReviewOnly GitHub Action implementation
+  - loop structure validator
+
+Boundaries:
+
+- Do not start the next queue.
+- Do not modify runtime behavior.
+- Do not claim completed work that was not verified.
+
+Verification:
+
+- Rust baseline
+- frontend build if frontend docs or paths are touched
+
+## Global stop conditions
+
+Stop immediately and hand off if any hard blocker from `specs/loop-engineering/SAFETY_GATES.md` appears.
+
+Also stop if:
+
+- scope expands beyond this queue
+- a task requires dependency changes
+- a task requires API behavior changes outside the smoke's verification purpose
+- a task requires frontend runtime changes beyond narrow scope
+- a task requires autonomous execution changes
+- verification fails
+- source-of-truth docs conflict
+- human approval is unclear
+
+## Human approval gate
+
+Agents must not merge PRs.
+
+The operator reviews and approves final merges.


### PR DESCRIPTION
## Summary

Add the Phase 2 full-stack compatibility smoke queue (definition only). This follows the #67 handoff recommendation and the `frontend-api-compatibility-plan.md` Phase 2 section.

## Mode

Epic Completion Mode (queue definition; execution is a separate approved run)

## Approved scope

Queue: `specs/active/phase2-fullstack-compat-smoke/QUEUE.md` (recommended next queue after #68).

## Tasks defined (not executed in this PR)

- Task 1 — Full-stack smoke script: build the Rust binary, start `prometheos serve`, `curl` `GET /health` + project CRUD cycle, tear down. Shell + `curl` only, no new dependencies.
- Task 2 — CI integration: add a separate CI job running the smoke after the Rust build.
- Task 3 — Queue handoff and next-loop recommendation.

## Files changed

- `specs/active/phase2-fullstack-compat-smoke/QUEUE.md` — queue definition.
- `specs/active/phase2-fullstack-compat-smoke/PROGRESS.md` — progress tracking (queue defined, not executed).
- `specs/active/phase2-fullstack-compat-smoke/HANDOFF.md` — handoff (planning only).

## Safety boundary

- No stable alpha changes.
- No frontend / API / autonomous promotion.
- No dependency additions.
- No API/runtime behavior changes (queue definition is docs-only).
- No `prometheos work` behavior changes.

## Verification

Docs-only change. No Rust or frontend behavior changed, so per `docs/LOOP_ENGINEERING.md` (docs-only rule) no `cargo` / `npm` build was required.

Queue scope cross-checked against source-of-truth docs:

| Queue claim | Source match |
|---|---|
| Phase 2 builds binary, starts `prometheos serve`, curls frontend-reachable routes | `frontend-api-compatibility-plan.md` Phase 2 section |
| Routes verified: health + project CRUD | matches Phase 1 routes in `tests/api_frontend_compatibility.rs` and compatibility plan Step 1–2 |
| No Playwright / no new deps / no frontend source change | matches `frontend-smoke-strategy.md` (Level 4 excluded) and plan "what this does NOT do" |
| API server / frontend remain experimental | `docs/guides/product-surface-inventory.md` (serve = experimental, frontend = experimental) |

## Known limitations

- This PR defines the queue; it does not run the smoke, add CI, or modify any runtime/source file. Execution is a follow-up Epic Completion PR (#70 or later).

## Follow-ups

After merge, execute under Epic Completion Mode. Secondary future candidates (not in this queue): Level 3 API connectivity smoke, ReviewOnly GitHub Action, loop structure validator.

## Human review gate

This PR requires human approval before merge.
