### PR TITLE
feat: add ReviewOnly GitHub Action v0 (#70)

### DIFF
--- a/.github/workflows/prometheos-reviewonly.yml
+++ b/.github/workflows/prometheos-reviewonly.yml
@@ -1,0 +1,23 @@
+name: PrometheOS ReviewOnly
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  reviewonly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run deterministic ReviewOnly reviewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: node scripts/reviewonly/reviewonly.mjs

--- a/docs/guides/prometheos-reviewonly-github-flow.md
+++ b/docs/guides/prometheos-reviewonly-github-flow.md
@@ -1,17 +1,20 @@
 # PrometheOS ReviewOnly — Planned GitHub Automation Flow
 
-This document describes the future ReviewOnly GitHub automation flow.
+This document describes the ReviewOnly GitHub automation flow.
 
 ReviewOnly is the PrometheOS-native equivalent of Claude Code's automatic PR review mode. It provides read-only diff review via a GitHub Action that posts structured review comments.
 
-This is a **planned design**. No automation has been implemented yet.
+## Implementation status
+
+- **v0 (implemented):** deterministic, read-only reviewer. No external models are invoked. It runs as `.github/workflows/prometheos-reviewonly.yml` and uses `scripts/reviewonly/reviewonly.mjs` to inspect the PR metadata/diff and post one structured ReviewOnly report comment.
+- No LLM-powered review yet. The deterministic v0 is the first automation step so the governance layer can be proven before any model or provider dependency is introduced.
 
 ## Level 1: ReviewOnly
 
 | Property       | Value                                    |
-|----------------|------------------------------------------|
-| Trigger        | `pull_request` opened/synchronize        |
-| Permissions    | read-only diff review, comments only     |
+| -------------- | ---------------------------------------- |
+| Trigger        | `pull_request` opened/synchronize/reopened |
+| Permissions    | `contents: read`, `pull-requests: write` |
 | Writes         | review comments only                     |
 | No commits     | yes                                      |
 | No branch writes | yes                                    |
@@ -19,6 +22,16 @@ This is a **planned design**. No automation has been implemented yet.
 | No issue-to-PR | yes                                      |
 | No dependency changes | yes                              |
 | No code modification | yes                              |
+| Model invoked  | no (v0 is deterministic)                 |
+
+### v0 implementation
+
+- Workflow: `.github/workflows/prometheos-reviewonly.yml`
+- Script: `scripts/reviewonly/reviewonly.mjs` (Node, no npm package, no model)
+- Behavior: reads PR metadata + diff, reads repo agent/safety docs, produces one structured ReviewOnly report comment (deduped across pushes), and exits 0 so it never blocks CI.
+- Blocker-level checks: dependency files changed without approval, CI/workflow weakening, secrets/credentials, conflict markers, promotion/overclaim of experimental surfaces, benchmark claims without evidence.
+- Warning-level checks: >5 files, >200 net lines, runtime/API/frontend paths touched, missing verification for the touched area, docs-only claim with runtime files changed.
+- The bot posts a normal comment; it does **not** open a formal blocking review, commit, write branches, or merge.
 
 ## Reviewer behavior
 

--- a/scripts/reviewonly/reviewonly.mjs
+++ b/scripts/reviewonly/reviewonly.mjs
@@ -2,38 +2,45 @@
 // PrometheOS ReviewOnly v0 — deterministic, read-only PR reviewer.
 //
 // No external models. No file edits. No commits. No merges.
-// Reads PR metadata + diff and the repo's agent/safety docs, then posts one
-// structured ReviewOnly report comment.
+// Reads PR metadata + diff and posts one structured ReviewOnly report comment.
 //
-// Designed to run inside GitHub Actions with `gh` available and
-// `pull-requests: write` permission for posting the comment only.
+// Runs inside GitHub Actions with `gh` available and `pull-requests: write`
+// permission for posting the comment only.
+//
+// Safety: all `gh` calls use execFileSync with an argv array (no shell
+// interpolation), and report bodies are passed through stdin via `--input -`.
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const PR = process.env.PR_NUMBER;
+const REPO = process.env.REPO; // owner/repo
 const GH_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
 
-function gh(args, input) {
+// argv-array form: never goes through a shell, so diff/filename/report content
+// cannot be interpreted as shell syntax.
+function gh(argv, input) {
   const opts = { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] };
   if (input !== undefined) opts.input = input;
-  return execSync(`gh ${args}`, opts).toString();
+  return execFileSync("gh", argv, opts).toString();
 }
 
-// ---- helpers ---------------------------------------------------------------
-
-function runGhJson(args) {
-  return JSON.parse(gh(args));
+function runGhJson(argv) {
+  return JSON.parse(gh(argv));
 }
 
 function getPrData() {
-  return runGhJson(
-    `pr view ${PR} --json number,title,body,additions,deletions,changedFiles,files,baseRefName,headRefName,state,url`,
-  );
+  return runGhJson([
+    "pr",
+    "view",
+    String(PR),
+    "--json",
+    "number,title,body,additions,deletions,changedFiles,files,baseRefName,headRefName,state,url",
+  ]);
 }
 
 function getDiff() {
   try {
-    return gh(`pr diff ${PR}`);
+    return gh(["pr", "diff", String(PR)]);
   } catch {
     return "";
   }
@@ -41,8 +48,7 @@ function getDiff() {
 
 function getCiStatus() {
   try {
-    const out = gh(`pr checks ${PR} --json name,state,conclusion 2>/dev/null`);
-    const arr = JSON.parse(out);
+    const arr = JSON.parse(gh(["pr", "checks", String(PR), "--json", "name,state,conclusion"]));
     if (!Array.isArray(arr) || arr.length === 0) return "unavailable";
     return arr
       .map((c) => `${c.name}: ${c.state}${c.conclusion ? " (" + c.conclusion + ")" : ""}`)
@@ -52,7 +58,7 @@ function getCiStatus() {
   }
 }
 
-// ---- analysis --------------------------------------------------------------
+// ---- analysis helpers ------------------------------------------------------
 
 const DEPENDENCY_FILES = [
   "cargo.toml",
@@ -92,8 +98,9 @@ const SECRET_RE = [
   /github_pat_[A-Za-z0-9_]{20,}/,
 ];
 
-const PROMOTION_RE = /(promote|now stable|is now stable|stable alpha|promoted to stable|alpha-promised|alpha promised)/i;
 const EXPERIMENTAL_SURFACE_RE = /(frontend|api server|api_server|autonomous|brain|mnemosyne|plugin marketplace|cloud\/team|control plane)/i;
+const AFFIRM_PROMO_RE = /(is (now )?stable alpha|stable alpha|promoted (to |into )?(stable|alpha)|alpha[- ]?promised|now part of stable alpha|becomes stable|is now stable|part of (the )?stable alpha|promote .{0,40} to stable)/i;
+const NEGATION_RE = /\b(no|not|never|without|does not|doesn't|avoid|avoided|unpromoted|not part of stable alpha|future|not alpha|experimental)\b/i;
 const BENCHMARK_RE = /(benchmark|outperform|sota|state-of-the-art|beats|surpass|better than \w+ by)/i;
 const EVIDENCE_RE = /(verified|evidence|cargo test|cargo clippy|npm run build|npm ci|validation|ran the checks)/i;
 
@@ -115,6 +122,26 @@ function basename(p) {
   return p.split("/").pop().toLowerCase();
 }
 
+// Promotion/overclaim: require AFFIRMATIVE promotion language. Negated
+// safety-boundary phrasing ("No frontend promotion", "experimental", "future /
+// not alpha") is exempt. Uncertain matches downgrade to Warning.
+function classifyPromotion(text) {
+  let blocker = false;
+  let warning = false;
+  for (const line of text.split("\n")) {
+    if (!EXPERIMENTAL_SURFACE_RE.test(line)) continue;
+    if (NEGATION_RE.test(line)) continue; // safety-boundary language, ignore
+    if (AFFIRM_PROMO_RE.test(line)) {
+      blocker = true;
+    } else if (/(stable alpha|promot|alpha)/i.test(line)) {
+      warning = true;
+    }
+  }
+  if (blocker) return "blocker";
+  if (warning) return "warning";
+  return null;
+}
+
 function analyze(pr, diff) {
   const findings = { Blockers: [], Warnings: [], Suggestions: [], Questions: [] };
   const add = (sev, text) => findings[sev].push(text);
@@ -129,12 +156,19 @@ function analyze(pr, diff) {
   const netLines = (pr.additions || 0) - (pr.deletions || 0);
   const body = pr.body || "";
 
+  // Touched-area classification.
+  const srcTouched =
+    files.some((f) => /^src\//i.test(f.path)) ||
+    files.some((f) => /^cargo\.(toml|lock)$/i.test(f.path));
+  const frontendTouched = files.some((f) => /^frontend\//i.test(f.path));
+  const workflowTouched = files.some((f) => /^\.github\//i.test(f.path));
+  const docsTouched = files.some((f) => /^docs\//i.test(f.path) || /\.md$/i.test(f.path));
+  const scriptTouched = files.some((f) => /^scripts\//i.test(f.path) || /\.mjs$/i.test(f.path));
+  const experimentalTouched = files.filter((f) => EXPERIMENTAL_PATH_PATTERNS.some((re) => re.test(f.path)));
+
   // --- blockers ------------------------------------------------------------
 
-  const depFiles = files.filter((f) =>
-    DEPENDENCY_FILES.includes(basename(f.path)) ||
-    /\.(csproj|toml|lock|gradle)$/i.test(f.path) && DEPENDENCY_FILES.some((d) => f.path.toLowerCase().endsWith(d)),
-  );
+  const depFiles = files.filter((f) => DEPENDENCY_FILES.includes(basename(f.path)));
   if (depFiles.length > 0) {
     add(
       "Blockers",
@@ -143,8 +177,7 @@ function analyze(pr, diff) {
     );
   }
 
-  const workflowFiles = files.filter((f) => /^\.github\//i.test(f.path));
-  if (workflowFiles.length > 0) {
+  if (workflowTouched) {
     const removed = removedLines(diff).join("\n").toLowerCase();
     const weakened =
       /cargo test/.test(removed) ||
@@ -154,16 +187,18 @@ function analyze(pr, diff) {
     if (weakened) {
       add(
         "Blockers",
-        `CI/workflow files changed and required checks appear removed: ${workflowFiles
+        `CI/workflow files changed and required checks appear removed (${files
+          .filter((f) => /^\.github\//i.test(f.path))
           .map((f) => f.path)
-          .join(", ")}. Possible CI weakening (SAFETY_GATES hard blocker).`,
+          .join(", ")}). Possible CI weakening (SAFETY_GATES hard blocker).`,
       );
     } else {
       add(
         "Warnings",
-        `CI/workflow files changed: ${workflowFiles
+        `CI/workflow files changed (${files
+          .filter((f) => /^\.github\//i.test(f.path))
           .map((f) => f.path)
-          .join(", ")}. Verify CI was not weakened (no check removed).`,
+          .join(", ")}). Verify CI was not weakened (no check removed).`,
       );
     }
   }
@@ -191,16 +226,20 @@ function analyze(pr, diff) {
     add("Blockers", `Source-of-truth conflict markers detected in diff (${conflictMarkers.length} line(s)).`);
   }
 
-  // promotion / overclaim (blocker if explicit promotion phrasing)
   const promotionScope = body + "\n" + addedLines(diff).join("\n");
-  if (PROMOTION_RE.test(promotionScope) && EXPERIMENTAL_SURFACE_RE.test(promotionScope)) {
+  const promo = classifyPromotion(promotionScope);
+  if (promo === "blocker") {
     add(
       "Blockers",
-      `Possible promotion/overclaim of an experimental surface to stable alpha. PR text or diff mentions stable alpha together with an experimental surface (frontend/API/autonomous/Brain/Mnemosyne). Per AGENTS.md rules, no frontend/API/autonomous promotion.`,
+      `Possible promotion/overclaim of an experimental surface to stable alpha. PR text or diff contains affirmative promotion language for an experimental surface (frontend/API/autonomous/Brain/Mnemosyne). Per AGENTS.md rules, no frontend/API/autonomous promotion.`,
+    );
+  } else if (promo === "warning") {
+    add(
+      "Warnings",
+      `Mentions an experimental surface together with promotion/stable-alpha language. Confirm this is not a promotion claim (negated safety-boundary language is exempt).`,
     );
   }
 
-  // benchmark claims without evidence
   if (BENCHMARK_RE.test(promotionScope) && !EVIDENCE_RE.test(promotionScope)) {
     add(
       "Blockers",
@@ -217,9 +256,6 @@ function analyze(pr, diff) {
     add("Warnings", `Net lines changed (${netLines}) exceed the default 200-line budget. Prefer small PRs.`);
   }
 
-  const experimentalTouched = files.filter((f) =>
-    EXPERIMENTAL_PATH_PATTERNS.some((re) => re.test(f.path)),
-  );
   if (experimentalTouched.length > 0) {
     add(
       "Warnings",
@@ -229,15 +265,11 @@ function analyze(pr, diff) {
     );
   }
 
-  const isDocsOnlyClaim =
-    /^docs:/i.test(pr.title || "") || /docs-only/i.test(body);
-  const runtimeTouched = files.some(
-    (f) => /^src\//i.test(f.path) || /^frontend\//i.test(f.path) || /^\.github\//i.test(f.path),
-  );
-  if (isDocsOnlyClaim && runtimeTouched) {
+  const isDocsOnlyClaim = /^docs:/i.test(pr.title || "") || /docs-only/i.test(body);
+  if (isDocsOnlyClaim && (srcTouched || frontendTouched || workflowTouched || scriptTouched)) {
     add(
       "Warnings",
-      `PR claims docs-only but touches runtime/API/frontend/workflow files. Verification must cover the changed area.`,
+      `PR claims docs-only but touches non-docs files (src/frontend/workflow/scripts). Verification must cover the changed area.`,
     );
   }
 
@@ -250,13 +282,21 @@ function analyze(pr, diff) {
   if (/npm (run )?build/i.test(body)) claimedChecks.push("npm run build");
   if (/npm (run )?lint/i.test(body)) claimedChecks.push("npm run lint");
   if (/npm ci/i.test(body)) claimedChecks.push("npm ci");
+  if (/node --check/i.test(body)) claimedChecks.push("node --check");
+  if (/reviewonly action|self-trigger|self trigger/i.test(body)) claimedChecks.push("ReviewOnly action self-trigger");
+  if (/ci (green|pass)|all ci workflows are green|ci workflows are green/i.test(body)) claimedChecks.push("CI green");
 
   const missingChecks = [];
-  if (runtimeTouched && !claimedChecks.some((c) => /cargo/i.test(c))) {
-    missingChecks.push("Rust baseline (cargo fmt/check/test/clippy) not referenced for touched src code");
+  if (srcTouched && !claimedChecks.some((c) => /cargo/i.test(c))) {
+    missingChecks.push("Rust baseline (cargo fmt/check/test/clippy) not referenced for touched src/Cargo code");
   }
-  if (experimentalTouched.some((f) => /^frontend\//i.test(f.path)) && !claimedChecks.some((c) => /npm/i.test(c))) {
+  if (frontendTouched && !claimedChecks.some((c) => /npm/i.test(c))) {
     missingChecks.push("Frontend build/lint not referenced for touched frontend code");
+  }
+  if ((workflowTouched || scriptTouched) && !claimedChecks.some((c) => /node --check|self-trigger|ci/i.test(c))) {
+    missingChecks.push(
+      "For workflow/script changes, expected evidence is `node --check`, ReviewOnly action self-trigger, and CI green",
+    );
   }
   if (missingChecks.length > 0) {
     add("Warnings", `Missing verification evidence: ${missingChecks.join("; ")}.`);
@@ -264,21 +304,36 @@ function analyze(pr, diff) {
 
   // --- suggestions / questions ---------------------------------------------
 
-  if (experimentalTouched.length === 0 && runtimeTouched === false && fileCount <= 5 && netLines <= 200) {
+  if (!srcTouched && !frontendTouched && fileCount <= 5 && netLines <= 200) {
     add("Suggestions", "Scope is small and within budget. Good.");
   }
   if (!body || body.trim().length < 40) {
     add("Questions", "PR body is thin. Include Summary, Safety boundary, and Verification sections per PR_TEMPLATE.md.");
   }
 
-  return { findings, fileCount, netLines, claimedChecks, missingChecks, experimentalTouched };
+  return {
+    findings,
+    fileCount,
+    netLines,
+    claimedChecks,
+    missingChecks,
+    experimentalTouched,
+    srcTouched,
+    frontendTouched,
+    workflowTouched,
+    docsTouched,
+    scriptTouched,
+  };
 }
 
 // ---- report ----------------------------------------------------------------
 
-function buildReport(pr, analysis, ciStatus) {
-  const { findings, fileCount, netLines, claimedChecks, missingChecks, experimentalTouched } = analysis;
-  const budget = fileCount <= 5 && netLines <= 200 ? "within default budget (<=5 files, <=200 net lines)" : "OVER BUDGET (>5 files or >200 net lines)";
+function buildReport(pr, a, ciStatus) {
+  const { findings, fileCount, netLines, claimedChecks, missingChecks, experimentalTouched } = a;
+  const budget =
+    fileCount <= 5 && netLines <= 200
+      ? "within default budget (<=5 files, <=200 net lines)"
+      : "OVER BUDGET (>5 files or >200 net lines)";
 
   const lines = [];
   lines.push("## PrometheOS ReviewOnly Report");
@@ -289,7 +344,9 @@ function buildReport(pr, analysis, ciStatus) {
   lines.push(`- Files reviewed: ${fileCount}`);
   lines.push(`- Lines changed: +${pr.additions || 0} / -${pr.deletions || 0} (net ${netLines})`);
   lines.push(`- Budget status: ${budget}`);
-  lines.push(`- Risky path categories touched: ${experimentalTouched.length > 0 ? experimentalTouched.map((f) => f.path).join(", ") : "none"}`);
+  lines.push(
+    `- Risky path categories touched: ${experimentalTouched.length > 0 ? experimentalTouched.map((f) => f.path).join(", ") : "none"}`,
+  );
   lines.push("");
   lines.push("Findings:");
   for (const sev of ["Blockers", "Warnings", "Suggestions", "Questions"]) {
@@ -307,11 +364,27 @@ function buildReport(pr, analysis, ciStatus) {
   lines.push(`- CI status: ${ciStatus}`);
   lines.push("");
   lines.push("Product boundary check:");
-  const stableAlphaImpact =
-    analysis.experimentalTouched.length === 0 && !/^src\//i.test("") ? "none detected" : "see experimental surface findings";
-  lines.push(`- Stable alpha: ${findings.Blockers.some((b) => /stable alpha/i.test(b)) ? "BLOCKER — possible stable alpha scope change" : "no direct change detected"}`);
-  lines.push(`- Experimental surfaces: ${experimentalTouched.length > 0 ? "touched (must stay experimental)" : "none touched"}`);
-  lines.push(`- Overclaim risk: ${findings.Blockers.some((b) => /overclaim|promotion/i.test(b)) ? "HIGH — possible promotion/overclaim" : "low"}`);
+  lines.push(
+    `- Stable alpha: ${
+      findings.Blockers.some((b) => /stable alpha/i.test(b))
+        ? "BLOCKER — possible stable alpha scope change"
+        : a.srcTouched
+          ? "src/Cargo touched — verify no stable-alpha behavior change"
+          : "no direct change detected"
+    }`,
+  );
+  lines.push(
+    `- Experimental surfaces: ${experimentalTouched.length > 0 ? "touched (must stay experimental)" : "none touched"}`,
+  );
+  lines.push(
+    `- Overclaim risk: ${
+      findings.Blockers.some((b) => /overclaim|promotion/i.test(b))
+        ? "HIGH — possible promotion/overclaim"
+        : findings.Warnings.some((w) => /promotion|stable.alpha/i.test(w))
+          ? "MEDIUM — review promotion language"
+          : "low"
+    }`,
+  );
   lines.push("");
   lines.push("Recommendation:");
   lines.push("- Wait for CI to be green before merge.");
@@ -321,15 +394,17 @@ function buildReport(pr, analysis, ciStatus) {
   }
   lines.push("");
   lines.push("---");
-  lines.push("_Deterministic ReviewOnly v0. No model invoked. Comments only; no commits, no branch writes, no merge._");
+  lines.push(
+    "_Deterministic ReviewOnly v0. No model invoked. Comments only; no commits, no branch writes, no merge._",
+  );
   return lines.join("\n");
 }
 
-// ---- post (with dedupe) ----------------------------------------------------
+// ---- post (argv-safe, body via stdin) -------------------------------------
 
 function findExistingComment() {
   try {
-    const comments = JSON.parse(gh(`api repos/${process.env.REPO}/issues/${PR}/comments?per_page=100`));
+    const comments = JSON.parse(gh(["api", `repos/${REPO}/issues/${PR}/comments?per_page=100`]));
     const marker = "## PrometheOS ReviewOnly Report";
     for (const c of comments) {
       if ((c.user?.login || "").includes("bot") && (c.body || "").includes(marker)) {
@@ -343,13 +418,25 @@ function findExistingComment() {
 }
 
 function postReport(report) {
+  const payload = JSON.stringify({ body: report });
   const existing = findExistingComment();
   if (existing) {
-    gh(`api -X PATCH repos/${process.env.REPO}/issues/comments/${existing} -f body=${JSON.stringify(report)}`);
+    gh(["api", "-X", "PATCH", `repos/${REPO}/issues/comments/${existing}`, "--input", "-"], payload);
     return "updated";
   }
-  gh(`pr comment ${PR} --body ${JSON.stringify(report)}`);
+  gh(["api", `repos/${REPO}/issues/${PR}/comments`, "--input", "-"], payload);
   return "created";
+}
+
+function postError(msg) {
+  try {
+    const payload = JSON.stringify({
+      body: `## PrometheOS ReviewOnly Report\n\nMode: ReviewOnly\n\nFindings:\n- Warnings: ${msg}\n\nRecommendation:\n- Human review required.`,
+    });
+    gh(["api", `repos/${REPO}/issues/${PR}/comments`, "--input", "-"], payload);
+  } catch {
+    /* never block CI */
+  }
 }
 
 // ---- main ------------------------------------------------------------------
@@ -362,17 +449,12 @@ try {
   const pr = getPrData();
   const diff = getDiff();
   const ciStatus = getCiStatus();
-  const analysis = analyze(pr, diff);
-  const report = buildReport(pr, analysis, ciStatus);
+  const a = analyze(pr, diff);
+  const report = buildReport(pr, a, ciStatus);
   const action = postReport(report);
   console.log(`ReviewOnly report ${action} for PR #${PR}.`);
   process.exit(0);
 } catch (err) {
-  const msg = `ReviewOnly v0 encountered an internal error: ${err && err.message ? err.message : String(err)}`;
-  try {
-    gh(`pr comment ${PR} --body ${JSON.stringify("## PrometheOS ReviewOnly Report\n\nMode: ReviewOnly\n\nFindings:\n- Warnings: " + msg + "\n\nRecommendation:\n- Human review required.")}`);
-  } catch {
-    /* give up silently; never block CI */
-  }
+  postError(`ReviewOnly v0 encountered an internal error: ${err && err.message ? err.message : String(err)}`);
   process.exit(0);
 }

--- a/scripts/reviewonly/reviewonly.mjs
+++ b/scripts/reviewonly/reviewonly.mjs
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+// PrometheOS ReviewOnly v0 — deterministic, read-only PR reviewer.
+//
+// No external models. No file edits. No commits. No merges.
+// Reads PR metadata + diff and the repo's agent/safety docs, then posts one
+// structured ReviewOnly report comment.
+//
+// Designed to run inside GitHub Actions with `gh` available and
+// `pull-requests: write` permission for posting the comment only.
+
+import { execSync } from "node:child_process";
+
+const PR = process.env.PR_NUMBER;
+const GH_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+
+function gh(args, input) {
+  const opts = { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] };
+  if (input !== undefined) opts.input = input;
+  return execSync(`gh ${args}`, opts).toString();
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function runGhJson(args) {
+  return JSON.parse(gh(args));
+}
+
+function getPrData() {
+  return runGhJson(
+    `pr view ${PR} --json number,title,body,additions,deletions,changedFiles,files,baseRefName,headRefName,state,url`,
+  );
+}
+
+function getDiff() {
+  try {
+    return gh(`pr diff ${PR}`);
+  } catch {
+    return "";
+  }
+}
+
+function getCiStatus() {
+  try {
+    const out = gh(`pr checks ${PR} --json name,state,conclusion 2>/dev/null`);
+    const arr = JSON.parse(out);
+    if (!Array.isArray(arr) || arr.length === 0) return "unavailable";
+    return arr
+      .map((c) => `${c.name}: ${c.state}${c.conclusion ? " (" + c.conclusion + ")" : ""}`)
+      .join("; ");
+  } catch {
+    return "unavailable";
+  }
+}
+
+// ---- analysis --------------------------------------------------------------
+
+const DEPENDENCY_FILES = [
+  "cargo.toml",
+  "cargo.lock",
+  "package.json",
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "gemfile",
+  "gemfile.lock",
+  "go.mod",
+  "go.sum",
+  "requirements.txt",
+  "pyproject.toml",
+  "pom.xml",
+  "build.gradle",
+];
+
+const EXPERIMENTAL_PATH_PATTERNS = [
+  /^src\/api\//i,
+  /^src\/serve\//i,
+  /^src\/flow\//i,
+  /^src\/harness\//i,
+  /^src\/brain\//i,
+  /^src\/mnemosyne\//i,
+  /^frontend\//i,
+  /^benchmark/i,
+  /^src\/llm\//i,
+];
+
+const SECRET_RE = [
+  /-----BEGIN (?:RSA |EC |OPENSSH |PGP |DSA )?PRIVATE KEY-----/,
+  /sk-[A-Za-z0-9]{20,}/,
+  /AKIA[0-9A-Z]{16}/,
+  /(api[_-]?key|secret|token|password|passwd|private[_-]?key)\s*[=:]\s*["'][^"']{8,}["']/i,
+  /ghp_[A-Za-z0-9]{30,}/,
+  /github_pat_[A-Za-z0-9_]{20,}/,
+];
+
+const PROMOTION_RE = /(promote|now stable|is now stable|stable alpha|promoted to stable|alpha-promised|alpha promised)/i;
+const EXPERIMENTAL_SURFACE_RE = /(frontend|api server|api_server|autonomous|brain|mnemosyne|plugin marketplace|cloud\/team|control plane)/i;
+const BENCHMARK_RE = /(benchmark|outperform|sota|state-of-the-art|beats|surpass|better than \w+ by)/i;
+const EVIDENCE_RE = /(verified|evidence|cargo test|cargo clippy|npm run build|npm ci|validation|ran the checks)/i;
+
+function addedLines(diff) {
+  return diff
+    .split("\n")
+    .filter((l) => l.startsWith("+") && !l.startsWith("+++"))
+    .map((l) => l.slice(1));
+}
+
+function removedLines(diff) {
+  return diff
+    .split("\n")
+    .filter((l) => l.startsWith("-") && !l.startsWith("---"))
+    .map((l) => l.slice(1));
+}
+
+function basename(p) {
+  return p.split("/").pop().toLowerCase();
+}
+
+function analyze(pr, diff) {
+  const findings = { Blockers: [], Warnings: [], Suggestions: [], Questions: [] };
+  const add = (sev, text) => findings[sev].push(text);
+
+  const files = (pr.files || []).map((f) => ({
+    path: f.path,
+    status: f.status,
+    additions: f.additions || 0,
+    deletions: f.deletions || 0,
+  }));
+  const fileCount = pr.changedFiles || files.length;
+  const netLines = (pr.additions || 0) - (pr.deletions || 0);
+  const body = pr.body || "";
+
+  // --- blockers ------------------------------------------------------------
+
+  const depFiles = files.filter((f) =>
+    DEPENDENCY_FILES.includes(basename(f.path)) ||
+    /\.(csproj|toml|lock|gradle)$/i.test(f.path) && DEPENDENCY_FILES.some((d) => f.path.toLowerCase().endsWith(d)),
+  );
+  if (depFiles.length > 0) {
+    add(
+      "Blockers",
+      `Dependency files changed without explicit approval: ${depFiles.map((f) => f.path).join(", ")}. ` +
+        `Per AGENTS.md, dependency changes require explicit approval.`,
+    );
+  }
+
+  const workflowFiles = files.filter((f) => /^\.github\//i.test(f.path));
+  if (workflowFiles.length > 0) {
+    const removed = removedLines(diff).join("\n").toLowerCase();
+    const weakened =
+      /cargo test/.test(removed) ||
+      /cargo clippy/.test(removed) ||
+      /npm run build/.test(removed) ||
+      /npm run lint/.test(removed);
+    if (weakened) {
+      add(
+        "Blockers",
+        `CI/workflow files changed and required checks appear removed: ${workflowFiles
+          .map((f) => f.path)
+          .join(", ")}. Possible CI weakening (SAFETY_GATES hard blocker).`,
+      );
+    } else {
+      add(
+        "Warnings",
+        `CI/workflow files changed: ${workflowFiles
+          .map((f) => f.path)
+          .join(", ")}. Verify CI was not weakened (no check removed).`,
+      );
+    }
+  }
+
+  const secretHits = [];
+  for (const line of addedLines(diff)) {
+    for (const re of SECRET_RE) {
+      if (re.test(line)) secretHits.push(line.trim().slice(0, 80));
+    }
+  }
+  if (secretHits.length > 0) {
+    add(
+      "Blockers",
+      `Possible secret/credential in diff: ${secretHits
+        .slice(0, 3)
+        .map((s) => `"${s}"`)
+        .join(", ")}. Do not commit secrets (SAFETY_GATES hard blocker).`,
+    );
+  }
+
+  const conflictMarkers = addedLines(diff).filter((l) =>
+    /^(<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|)/.test(l),
+  );
+  if (conflictMarkers.length > 0) {
+    add("Blockers", `Source-of-truth conflict markers detected in diff (${conflictMarkers.length} line(s)).`);
+  }
+
+  // promotion / overclaim (blocker if explicit promotion phrasing)
+  const promotionScope = body + "\n" + addedLines(diff).join("\n");
+  if (PROMOTION_RE.test(promotionScope) && EXPERIMENTAL_SURFACE_RE.test(promotionScope)) {
+    add(
+      "Blockers",
+      `Possible promotion/overclaim of an experimental surface to stable alpha. PR text or diff mentions stable alpha together with an experimental surface (frontend/API/autonomous/Brain/Mnemosyne). Per AGENTS.md rules, no frontend/API/autonomous promotion.`,
+    );
+  }
+
+  // benchmark claims without evidence
+  if (BENCHMARK_RE.test(promotionScope) && !EVIDENCE_RE.test(promotionScope)) {
+    add(
+      "Blockers",
+      `Benchmark/performance claim detected without verification evidence markers. Per AGENTS.md, benchmark claims require completed validation evidence.`,
+    );
+  }
+
+  // --- warnings -------------------------------------------------------------
+
+  if (fileCount > 5) {
+    add("Warnings", `Changed files (${fileCount}) exceed the default 5-file budget. Prefer small PRs.`);
+  }
+  if (netLines > 200) {
+    add("Warnings", `Net lines changed (${netLines}) exceed the default 200-line budget. Prefer small PRs.`);
+  }
+
+  const experimentalTouched = files.filter((f) =>
+    EXPERIMENTAL_PATH_PATTERNS.some((re) => re.test(f.path)),
+  );
+  if (experimentalTouched.length > 0) {
+    add(
+      "Warnings",
+      `Runtime/API/frontend/harness paths touched: ${experimentalTouched
+        .map((f) => f.path)
+        .join(", ")}. Keep experimental surfaces out of alpha scope.`,
+    );
+  }
+
+  const isDocsOnlyClaim =
+    /^docs:/i.test(pr.title || "") || /docs-only/i.test(body);
+  const runtimeTouched = files.some(
+    (f) => /^src\//i.test(f.path) || /^frontend\//i.test(f.path) || /^\.github\//i.test(f.path),
+  );
+  if (isDocsOnlyClaim && runtimeTouched) {
+    add(
+      "Warnings",
+      `PR claims docs-only but touches runtime/API/frontend/workflow files. Verification must cover the changed area.`,
+    );
+  }
+
+  // --- verification evidence ------------------------------------------------
+
+  const claimedChecks = [];
+  if (/cargo test/i.test(body)) claimedChecks.push("cargo test");
+  if (/cargo clippy/i.test(body)) claimedChecks.push("cargo clippy");
+  if (/cargo (fmt|check)/i.test(body)) claimedChecks.push("cargo fmt/check");
+  if (/npm (run )?build/i.test(body)) claimedChecks.push("npm run build");
+  if (/npm (run )?lint/i.test(body)) claimedChecks.push("npm run lint");
+  if (/npm ci/i.test(body)) claimedChecks.push("npm ci");
+
+  const missingChecks = [];
+  if (runtimeTouched && !claimedChecks.some((c) => /cargo/i.test(c))) {
+    missingChecks.push("Rust baseline (cargo fmt/check/test/clippy) not referenced for touched src code");
+  }
+  if (experimentalTouched.some((f) => /^frontend\//i.test(f.path)) && !claimedChecks.some((c) => /npm/i.test(c))) {
+    missingChecks.push("Frontend build/lint not referenced for touched frontend code");
+  }
+  if (missingChecks.length > 0) {
+    add("Warnings", `Missing verification evidence: ${missingChecks.join("; ")}.`);
+  }
+
+  // --- suggestions / questions ---------------------------------------------
+
+  if (experimentalTouched.length === 0 && runtimeTouched === false && fileCount <= 5 && netLines <= 200) {
+    add("Suggestions", "Scope is small and within budget. Good.");
+  }
+  if (!body || body.trim().length < 40) {
+    add("Questions", "PR body is thin. Include Summary, Safety boundary, and Verification sections per PR_TEMPLATE.md.");
+  }
+
+  return { findings, fileCount, netLines, claimedChecks, missingChecks, experimentalTouched };
+}
+
+// ---- report ----------------------------------------------------------------
+
+function buildReport(pr, analysis, ciStatus) {
+  const { findings, fileCount, netLines, claimedChecks, missingChecks, experimentalTouched } = analysis;
+  const budget = fileCount <= 5 && netLines <= 200 ? "within default budget (<=5 files, <=200 net lines)" : "OVER BUDGET (>5 files or >200 net lines)";
+
+  const lines = [];
+  lines.push("## PrometheOS ReviewOnly Report");
+  lines.push("");
+  lines.push("Mode: ReviewOnly");
+  lines.push("");
+  lines.push("Scope:");
+  lines.push(`- Files reviewed: ${fileCount}`);
+  lines.push(`- Lines changed: +${pr.additions || 0} / -${pr.deletions || 0} (net ${netLines})`);
+  lines.push(`- Budget status: ${budget}`);
+  lines.push(`- Risky path categories touched: ${experimentalTouched.length > 0 ? experimentalTouched.map((f) => f.path).join(", ") : "none"}`);
+  lines.push("");
+  lines.push("Findings:");
+  for (const sev of ["Blockers", "Warnings", "Suggestions", "Questions"]) {
+    const items = findings[sev];
+    if (items.length === 0) {
+      lines.push(`- ${sev}: none`);
+    } else {
+      for (const it of items) lines.push(`- ${sev}: ${it}`);
+    }
+  }
+  lines.push("");
+  lines.push("Verification evidence:");
+  lines.push(`- Claimed checks: ${claimedChecks.length > 0 ? claimedChecks.join(", ") : "none stated"}`);
+  lines.push(`- Missing checks: ${missingChecks.length > 0 ? missingChecks.join("; ") : "none detected"}`);
+  lines.push(`- CI status: ${ciStatus}`);
+  lines.push("");
+  lines.push("Product boundary check:");
+  const stableAlphaImpact =
+    analysis.experimentalTouched.length === 0 && !/^src\//i.test("") ? "none detected" : "see experimental surface findings";
+  lines.push(`- Stable alpha: ${findings.Blockers.some((b) => /stable alpha/i.test(b)) ? "BLOCKER — possible stable alpha scope change" : "no direct change detected"}`);
+  lines.push(`- Experimental surfaces: ${experimentalTouched.length > 0 ? "touched (must stay experimental)" : "none touched"}`);
+  lines.push(`- Overclaim risk: ${findings.Blockers.some((b) => /overclaim|promotion/i.test(b)) ? "HIGH — possible promotion/overclaim" : "low"}`);
+  lines.push("");
+  lines.push("Recommendation:");
+  lines.push("- Wait for CI to be green before merge.");
+  lines.push("- Human review required (ReviewOnly does not approve or merge).");
+  if (findings.Blockers.length > 0) {
+    lines.push("- Resolve blocker-level findings before merge.");
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("_Deterministic ReviewOnly v0. No model invoked. Comments only; no commits, no branch writes, no merge._");
+  return lines.join("\n");
+}
+
+// ---- post (with dedupe) ----------------------------------------------------
+
+function findExistingComment() {
+  try {
+    const comments = JSON.parse(gh(`api repos/${process.env.REPO}/issues/${PR}/comments?per_page=100`));
+    const marker = "## PrometheOS ReviewOnly Report";
+    for (const c of comments) {
+      if ((c.user?.login || "").includes("bot") && (c.body || "").includes(marker)) {
+        return c.id;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function postReport(report) {
+  const existing = findExistingComment();
+  if (existing) {
+    gh(`api -X PATCH repos/${process.env.REPO}/issues/comments/${existing} -f body=${JSON.stringify(report)}`);
+    return "updated";
+  }
+  gh(`pr comment ${PR} --body ${JSON.stringify(report)}`);
+  return "created";
+}
+
+// ---- main ------------------------------------------------------------------
+
+try {
+  if (!PR) {
+    console.error("PR_NUMBER not set");
+    process.exit(0);
+  }
+  const pr = getPrData();
+  const diff = getDiff();
+  const ciStatus = getCiStatus();
+  const analysis = analyze(pr, diff);
+  const report = buildReport(pr, analysis, ciStatus);
+  const action = postReport(report);
+  console.log(`ReviewOnly report ${action} for PR #${PR}.`);
+  process.exit(0);
+} catch (err) {
+  const msg = `ReviewOnly v0 encountered an internal error: ${err && err.message ? err.message : String(err)}`;
+  try {
+    gh(`pr comment ${PR} --body ${JSON.stringify("## PrometheOS ReviewOnly Report\n\nMode: ReviewOnly\n\nFindings:\n- Warnings: " + msg + "\n\nRecommendation:\n- Human review required.")}`);
+  } catch {
+    /* give up silently; never block CI */
+  }
+  process.exit(0);
+}

--- a/specs/active/reviewonly-github-action/HANDOFF.md
+++ b/specs/active/reviewonly-github-action/HANDOFF.md
@@ -1,0 +1,74 @@
+# ReviewOnly GitHub Action v0 Handoff
+
+## Current state
+
+Implementation complete. PR #70 is open for human review. The deterministic ReviewOnly v0 automation is implemented and self-tests by running on its own PR.
+
+## Completed work
+
+### Workflow — `.github/workflows/prometheos-reviewonly.yml`
+
+- Triggers on `pull_request` `opened` / `synchronize` / `reopened`.
+- Permissions: `contents: read`, `pull-requests: write` only.
+- Checks out the repo and runs `node scripts/reviewonly/reviewonly.mjs`.
+
+### Script — `scripts/reviewonly/reviewonly.mjs`
+
+- Deterministic, no external models, no npm dependencies.
+- Reads PR metadata + diff via `gh`.
+- Blocker-level checks: dependency files changed without approval, CI/workflow weakening, secrets/credentials, source-of-truth conflict markers, promotion/overclaim of experimental surfaces to stable alpha, benchmark claims without evidence.
+- Warning-level checks: >5 files, >200 net lines, runtime/API/frontend/harness paths touched, missing verification for touched area, docs-only claim with runtime files changed.
+- Produces one structured `## PrometheOS ReviewOnly Report` comment, deduped across pushes (edits the prior bot comment instead of stacking new ones).
+- Always exits 0 so it never blocks CI; internal errors surface as a warning comment.
+
+### Docs — `docs/guides/prometheos-reviewonly-github-flow.md`
+
+- Updated from "planned design, no automation" to reflect v0 implementation.
+- Added an "Implementation status" note and a "v0 implementation" subsection (workflow path, script path, behavior, checks, permission model).
+
+### Progress/handoff
+
+- `specs/active/reviewonly-github-action/PROGRESS.md`, `HANDOFF.md` (this file).
+
+**Files:** `.github/workflows/prometheos-reviewonly.yml`, `scripts/reviewonly/reviewonly.mjs`, `docs/guides/prometheos-reviewonly-github-flow.md`, `specs/active/reviewonly-github-action/PROGRESS.md`, `specs/active/reviewonly-github-action/HANDOFF.md`
+
+## Verification run
+
+| Command | Result |
+|---|---|
+| `node --check scripts/reviewonly/reviewonly.mjs` | passed |
+| Self-trigger CI | the action executes on PR #70 and posts a ReviewOnly report comment |
+
+No `cargo` / `npm` build required (GitHub Action + dependency-free Node script + docs).
+
+## What was not run
+
+- LLM-powered review — intentionally out of scope for v0.
+- Formal blocking review via `gh pr review --request-changes` — v0 posts a normal comment only, per the ReviewOnly spec.
+- Local end-to-end run against a real PR — the action is verified live by running on this PR in CI.
+
+## Blockers
+
+None encountered.
+
+## Risks
+
+- The bot posts on every PR opened/synchronize/reopened. Comment volume is bounded by dedupe (it edits its own prior comment). If `gh` permissions or the token change, the script degrades to a warning comment and still exits 0.
+- Promotion/overclaim and benchmark detection are keyword heuristics, not semantic analysis; they may produce false positives. They are flagged for human review, not auto-blocking the merge (the action cannot merge regardless).
+- v0 does not call models, so it cannot catch subtle logic issues a human reviewer would. It is a first-pass governance speedup, not a replacement for human review (per the ReviewOnly spec).
+
+## Next task
+
+None in this PR. After merge:
+- Observe the bot's comments across a few PRs; tune heuristics if noisy.
+- Level 3 API connectivity smoke (separate PR).
+- Loop structure validator (separate PR).
+- LLM-powered ReviewOnly (only after deterministic v0 is proven stable; separate PR, requires explicit approval).
+
+## Stop reason
+
+Implementation complete. Awaiting human review and merge.
+
+## Confidence
+
+High. Scope contained, no model dependency, no new npm packages, no behavioral promotion, permissions minimal, and the bot self-verifies by running on this PR.

--- a/specs/active/reviewonly-github-action/HANDOFF.md
+++ b/specs/active/reviewonly-github-action/HANDOFF.md
@@ -2,7 +2,7 @@
 
 ## Current state
 
-Implementation complete. PR #70 is open for human review. The deterministic ReviewOnly v0 automation is implemented and self-tests by running on its own PR.
+Implementation complete and patched. PR #70 is open for human review. The deterministic ReviewOnly v0 automation is implemented and self-tests by running on its own PR.
 
 ## Completed work
 
@@ -15,9 +15,11 @@ Implementation complete. PR #70 is open for human review. The deterministic Revi
 ### Script — `scripts/reviewonly/reviewonly.mjs`
 
 - Deterministic, no external models, no npm dependencies.
-- Reads PR metadata + diff via `gh`.
-- Blocker-level checks: dependency files changed without approval, CI/workflow weakening, secrets/credentials, source-of-truth conflict markers, promotion/overclaim of experimental surfaces to stable alpha, benchmark claims without evidence.
-- Warning-level checks: >5 files, >200 net lines, runtime/API/frontend/harness paths touched, missing verification for touched area, docs-only claim with runtime files changed.
+- Reads PR metadata + diff via `gh`, using `execFileSync("gh", argv, ...)` (argv array, no shell interpolation). Report bodies are passed through stdin (`--input -`).
+- Blocker-level checks: dependency files changed without approval, CI/workflow weakening, secrets/credentials, source-of-truth conflict markers, *affirmative* promotion/overclaim of experimental surfaces to stable alpha, benchmark claims without evidence.
+- Warning-level checks: >5 files, >200 net lines, runtime/API/frontend/harness paths touched, missing verification for touched area (classified by touched area), docs-only claim with non-docs files changed.
+- Promotion heuristic requires affirmative promotion language and exempts negated safety-boundary phrasing ("no", "not", "experimental", "future / not alpha"); uncertain matches downgrade to Warning.
+- Verification classification splits touched areas (`srcTouched`, `frontendTouched`, `workflowTouched`, `docsTouched`, `scriptTouched`); Rust baseline is required only for `src/**` / `Cargo.*` / Rust workflows, while workflow/script changes expect `node --check` + action self-trigger + CI green.
 - Produces one structured `## PrometheOS ReviewOnly Report` comment, deduped across pushes (edits the prior bot comment instead of stacking new ones).
 - Always exits 0 so it never blocks CI; internal errors surface as a warning comment.
 
@@ -49,12 +51,12 @@ No `cargo` / `npm` build required (GitHub Action + dependency-free Node script +
 
 ## Blockers
 
-None encountered.
+None in the final (patched) implementation. The first live self-trigger reported a false-positive blocker: the original overclaim heuristic matched normal safety-boundary language ("No frontend / API / autonomous promotion"). This was caught before merge and fixed by `classifyPromotion`, which requires affirmative promotion wording and exempts negated safety-boundary phrases. See `PROGRESS.md` patch notes.
 
 ## Risks
 
 - The bot posts on every PR opened/synchronize/reopened. Comment volume is bounded by dedupe (it edits its own prior comment). If `gh` permissions or the token change, the script degrades to a warning comment and still exits 0.
-- Promotion/overclaim and benchmark detection are keyword heuristics, not semantic analysis; they may produce false positives. They are flagged for human review, not auto-blocking the merge (the action cannot merge regardless).
+- Promotion/overclaim and benchmark detection are keyword heuristics, not semantic analysis; they may produce false positives. Affirmative-language requirements and negation exemptions reduce noise, but the checks are flagged for human review, not auto-blocking the merge (the action cannot merge regardless).
 - v0 does not call models, so it cannot catch subtle logic issues a human reviewer would. It is a first-pass governance speedup, not a replacement for human review (per the ReviewOnly spec).
 
 ## Next task

--- a/specs/active/reviewonly-github-action/PROGRESS.md
+++ b/specs/active/reviewonly-github-action/PROGRESS.md
@@ -39,9 +39,23 @@ None.
 
 - No model is invoked. v0 is fully deterministic.
 - Permissions are `contents: read`, `pull-requests: write` only. No branch writes, no merge, no commits.
+- All `gh` calls use `execFileSync` with an argv array (no shell interpolation); report bodies are passed via stdin (`--input -`). Diff, filename, and report content can no longer reach a shell.
 - The script exits 0 even on internal error so it never blocks CI; failures surface as a warning comment.
 - This is Level 1 (ReviewOnly) automation. It does not approve or merge PRs.
 - #69 (Phase 2 full-stack smoke queue) remains a registered backlog queue; this PR does not execute it.
+
+## Patch notes (self-trigger feedback)
+
+The first live ReviewOnly report on this PR exposed issues that were patched before merge:
+
+1. **Unsafe shell command construction** — `execSync(\`gh ${args}\`)` replaced with `execFileSync("gh", argv, ...)`. Report bodies now go through stdin, not shell arguments.
+2. **Overclaim heuristic false-flagged safety language** — the original regex blocked PRs mentioning experimental surfaces alongside "stable alpha" anywhere, which caught normal safety-boundary text ("No frontend / API / autonomous promotion"). The new `classifyPromotion` requires *affirmative* promotion language and exempts negated safety-boundary phrases ("no", "not", "experimental", "future / not alpha"); uncertain matches downgrade to Warning.
+3. **Wrong verification classification for workflow/script changes** — `.github/` was previously treated as "touched src code", inventing a missing Rust-baseline warning. Touched areas are now split (`srcTouched`, `frontendTouched`, `workflowTouched`, `docsTouched`, `scriptTouched`); Rust baseline is required only when `src/**` / `Cargo.*` / Rust workflows change, while workflow/script changes expect `node --check` + action self-trigger + CI green.
+4. **Claimed-check detection** now recognizes `node --check`, "ReviewOnly action self-trigger", and "CI green".
+
+## Budget note
+
+This PR is 5 files, +557 / -5. That exceeds the default 200-line preference. It is accepted because this is the first bounded implementation of Level 1 automation (workflow + script + docs + progress/handoff). Escalated per AGENTS.md minimality budget guidance.
 
 ## Verification evidence
 

--- a/specs/active/reviewonly-github-action/PROGRESS.md
+++ b/specs/active/reviewonly-github-action/PROGRESS.md
@@ -1,0 +1,64 @@
+# ReviewOnly GitHub Action v0 Progress
+
+## Mode
+
+Epic Completion Mode (single implementation PR; not a queue-definition PR)
+
+## Status
+
+Implementation complete. PR open for human review.
+
+## Approved scope
+
+Operator direction (updated from earlier #70 queue-definition plan):
+
+- Add `.github/workflows/prometheos-reviewonly.yml`
+- Add `scripts/reviewonly/reviewonly.mjs` (deterministic, no model)
+- Update `docs/guides/prometheos-reviewonly-github-flow.md` to reflect v0
+- Add `specs/active/reviewonly-github-action/PROGRESS.md` and `HANDOFF.md`
+
+## Current queue
+
+- [x] Implement ReviewOnly GitHub Action v0 (workflow + script + docs + progress/handoff)
+
+## Completed tasks
+
+| Task | Commit | Files | Verification | Notes |
+|---|---|---|---|---|
+| Implement ReviewOnly v0 | (this PR) | `.github/workflows/prometheos-reviewonly.yml`, `scripts/reviewonly/reviewonly.mjs`, `docs/guides/prometheos-reviewonly-github-flow.md`, `specs/active/reviewonly-github-action/PROGRESS.md`, `specs/active/reviewonly-github-action/HANDOFF.md` | `node --check` syntax valid; self-triggers on this PR for live verification | Deterministic, no model, comments only |
+
+## Current task
+
+None. Implementation complete.
+
+## Blockers
+
+None.
+
+## Scope notes
+
+- No model is invoked. v0 is fully deterministic.
+- Permissions are `contents: read`, `pull-requests: write` only. No branch writes, no merge, no commits.
+- The script exits 0 even on internal error so it never blocks CI; failures surface as a warning comment.
+- This is Level 1 (ReviewOnly) automation. It does not approve or merge PRs.
+- #69 (Phase 2 full-stack smoke queue) remains a registered backlog queue; this PR does not execute it.
+
+## Verification evidence
+
+| Command | Result |
+|---|---|
+| `node --check scripts/reviewonly/reviewonly.mjs` | passed (valid syntax) |
+| CI (self-trigger) | the action runs on this PR (#70) and posts a ReviewOnly report comment — live proof of behavior |
+
+No `cargo` / `npm` build required: the change is a GitHub Action + a Node script with no npm dependencies, plus docs.
+
+## Stop / continue decision
+
+Stop. Implementation complete. Create PR for human review.
+
+## Next recommended action
+
+Merge after CI green and human review. After merge, the bot runs on every PR automatically. Future work (separate PRs):
+- Level 3 API connectivity smoke (frontend reaches API server).
+- Loop structure validator.
+- LLM-powered ReviewOnly (only after the deterministic v0 is proven stable).


### PR DESCRIPTION
## Summary

Add the deterministic ReviewOnly GitHub Action v0 (Level 1 automation). This is the operating-system hardening step: it begins reducing manual review load by posting a structured, read-only review report on every PR. It does **not** call any model, does not edit files, does not commit, does not merge, and does not open formal blocking reviews.

## Mode

Epic Completion Mode (single implementation PR, not a queue-definition PR)

## Approved scope

Operator direction: implement ReviewOnly v0 as deterministic automation.

## Tasks completed

- Added `.github/workflows/prometheos-reviewonly.yml` (trigger `pull_request` opened/synchronize/reopened; `contents: read`, `pull-requests: write`).
- Added `scripts/reviewonly/reviewonly.mjs` (Node, no npm package, no model).
- Updated `docs/guides/prometheos-reviewonly-github-flow.md` from "planned, no automation" to reflect v0.
- Added `specs/active/reviewonly-github-action/PROGRESS.md` and `HANDOFF.md`.

## Files changed

- `.github/workflows/prometheos-reviewonly.yml` — the Action.
- `scripts/reviewonly/reviewonly.mjs` — deterministic reviewer (blocker/warning heuristics, structured report, dedupe, always exits 0).
- `docs/guides/prometheos-reviewonly-github-flow.md` — documents v0 and implementation status.
- `specs/active/reviewonly-github-action/PROGRESS.md`, `HANDOFF.md` — progress/handoff.

## Safety boundary

- No stable alpha changes.
- No frontend / API / autonomous promotion.
- No dependency additions (no new npm/cargo deps; script uses Node built-ins + `gh`).
- No API/runtime behavior changes.
- No `prometheos work` behavior changes.
- Permissions minimal: comments only. No branch writes, no merge, no commits.
- No model/LLM invoked.

## Verification

| Command | Result |
|---|---|
| `node --check scripts/reviewonly/reviewonly.mjs` | passed |
| Self-trigger CI | the action runs on this PR (#70) and posts a ReviewOnly report comment |

No `cargo` / `npm` build required (GitHub Action + dependency-free Node script + docs).

## What the bot reports

`## PrometheOS ReviewOnly Report` with Scope, Findings (Blockers/Warnings/Suggestions/Questions), Verification evidence, Product boundary check, and Recommendation. Blockers flagged: dependency files without approval, CI weakening, secrets, conflict markers, promotion/overclaim of experimental surfaces, benchmark claims without evidence. Warnings: >5 files, >200 net lines, runtime/API/frontend paths touched, missing verification, docs-only claim with runtime files changed.

## Known limitations

- Keyword heuristics, not semantic analysis; may false-positive. Flags are for human review, and the bot cannot merge regardless.
- v0 posts a normal comment, not a formal blocking review.
- LLM-powered review is explicitly out of scope for v0.

## Follow-ups

- Observe bot comments across a few PRs; tune heuristics if noisy.
- Level 3 API connectivity smoke (separate PR).
- Loop structure validator (separate PR).
- LLM-powered ReviewOnly (only after deterministic v0 is proven stable; separate PR, requires explicit approval).

## Human review gate

This PR requires human approval before merge. After merge, the bot runs automatically on every PR.
