### PR TITLE
feat: add approval-controlled patch workflow (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,21 @@ jobs:
       - name: Run full-stack smoke
         run: bash scripts/fullstack-smoke.sh
 
+  approval-controlled-patch-smoke:
+    name: Approval-Controlled Patch Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run approval-controlled patch workflow smoke
+        run: bash scripts/approval-controlled-patch-smoke.sh
+

--- a/scripts/approval-controlled-patch-smoke.sh
+++ b/scripts/approval-controlled-patch-smoke.sh
@@ -90,6 +90,34 @@ echo "   tree patched (good)"
 git -C "$REPO" add -A
 git -C "$REPO" commit -qm "applied fix via approval-controlled workflow"
 
+echo "== 5.5 approval before dry-run is refused =="
+PATCHX="$WORK/revert.patch"
+cat > "$PATCHX" <<'EOF'
+--- a/src/calc.rs
++++ b/src/calc.rs
+@@ -1 +1 @@
+-pub fn add(a: i32, b: i32) -> i32 { a + b }
++pub fn add(a: i32, b: i32) -> i32 { a - b }
+EOF
+PHASHX="$(sha256sum "$PATCHX" | cut -d' ' -f1)"
+IDX="$("$BIN" workflow propose --repo "$REPO" --goal "revert" --authority assist --patch "$PATCHX" --allowed "src/**")"
+if "$BIN" workflow approve --repo "$REPO" "$IDX" --patch-hash "$PHASHX" 2>/dev/null; then
+  echo "FAIL: approval succeeded before dry-run"; exit 1
+fi
+echo "   refused (good)"
+
+echo "== 5.6 apply after HEAD moved is refused =="
+"$BIN" workflow dry-run --repo "$REPO" "$IDX" --validate "grep -q 'a - b' src/calc.rs"
+"$BIN" workflow approve --repo "$REPO" "$IDX" --patch-hash "$PHASHX"
+# Move the repository HEAD away from the validated base.
+echo "// unrelated committed change" >> src/lib.rs
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm "move repository head"
+if "$BIN" workflow apply --repo "$REPO" "$IDX" --patch-hash "$PHASHX" 2>/dev/null; then
+  echo "FAIL: stale proposal applied after HEAD changed"; exit 1
+fi
+echo "   refused (good)"
+
 echo "== 6. rollback restores tree on validation failure =="
 PATCH2="$WORK/break.patch"
 cat > "$PATCH2" <<'EOF'

--- a/scripts/approval-controlled-patch-smoke.sh
+++ b/scripts/approval-controlled-patch-smoke.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Approval-controlled patch workflow golden path.
+#
+# Builds the binary, creates a throwaway git repo with a boundary bug, then drives
+# the full safe path through the CLI:
+#
+#   propose -> dry-run -> approve -> apply -> validate -> report
+#
+# and proves:
+#   - a patch is rejected unless scope passes (negative test)
+#   - dry-run isolates changes in a worktree
+#   - apply refuses without approval / wrong hash
+#   - apply mutates the tree only after matching approval
+#   - rollback restores the tree when validation fails
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps 2>/dev/null | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')"
+TARGET_DIR="${TARGET_DIR:-$ROOT/target}"
+case "$(uname -s)" in
+  MINGW* | MSYS* | CYGWIN*) BIN="$TARGET_DIR/debug/prometheos.exe" ;;
+  *) BIN="$TARGET_DIR/debug/prometheos" ;;
+esac
+[ -x "$BIN" ] || BIN="$TARGET_DIR/debug/prometheos"
+
+echo "Building prometheos..."
+cargo build --bin prometheos
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+mkdir -p "$REPO/src"
+cd "$REPO"
+git init -q
+git config user.email "smoke@prometheos.local"
+git config user.name "smoke"
+
+cat > Cargo.toml <<'EOF'
+[package]
+name = "repro"
+version = "0.1.0"
+edition = "2021"
+EOF
+cat > src/lib.rs <<'EOF'
+pub mod calc;
+EOF
+cat > src/calc.rs <<'EOF'
+pub fn add(a: i32, b: i32) -> i32 { a - b }
+EOF
+git add -A
+git commit -qm "initial"
+
+PATCH="$WORK/fix.patch"
+cat > "$PATCH" <<'EOF'
+--- a/src/calc.rs
++++ b/src/calc.rs
+@@ -1 +1 @@
+-pub fn add(a: i32, b: i32) -> i32 { a - b }
++pub fn add(a: i32, b: i32) -> i32 { a + b }
+EOF
+
+PHASH="$(sha256sum "$PATCH" | cut -d' ' -f1)"
+
+echo "== 1. propose (scope ok) =="
+ID="$("$BIN" workflow propose --repo "$REPO" --goal "fix add boundary" --authority assist --patch "$PATCH" --allowed "src/**")"
+echo "   id=$ID"
+[ -n "$ID" ] || { echo "FAIL: propose returned no id"; exit 1; }
+
+echo "== 2. apply refuses without approval =="
+if "$BIN" workflow apply --repo "$REPO" "$ID" --patch-hash "$PHASH" --no-rollback 2>/dev/null; then
+  echo "FAIL: apply succeeded without approval"; exit 1
+fi
+echo "   refused (good)"
+
+echo "== 3. dry-run passes in isolated worktree =="
+if ! "$BIN" workflow dry-run --repo "$REPO" "$ID" --validate "grep -q 'a + b' src/calc.rs"; then
+  echo "FAIL: dry-run should pass"; exit 1
+fi
+
+echo "== 4. approve =="
+"$BIN" workflow approve --repo "$REPO" "$ID" --patch-hash "$PHASH"
+
+echo "== 5. apply (with approval) mutates tree =="
+"$BIN" workflow apply --repo "$REPO" "$ID" --patch-hash "$PHASH" --validate "grep -q 'a + b' src/calc.rs"
+grep -q 'a + b' src/calc.rs || { echo "FAIL: tree not patched"; exit 1; }
+echo "   tree patched (good)"
+# Commit so the next apply starts from a clean tree (simulates user review + commit).
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm "applied fix via approval-controlled workflow"
+
+echo "== 6. rollback restores tree on validation failure =="
+PATCH2="$WORK/break.patch"
+cat > "$PATCH2" <<'EOF'
+--- a/src/calc.rs
++++ b/src/calc.rs
+@@ -1 +1 @@
+-pub fn add(a: i32, b: i32) -> i32 { a + b }
++pub fn add(a: i32, b: i32) -> i32 { a * b }
+EOF
+PHASH2="$(sha256sum "$PATCH2" | cut -d' ' -f1)"
+ID2="$("$BIN" workflow propose --repo "$REPO" --goal "change op" --authority assist --patch "$PATCH2" --allowed "src/**")"
+"$BIN" workflow dry-run --repo "$REPO" "$ID2" >/dev/null
+"$BIN" workflow approve --repo "$REPO" "$ID2" --patch-hash "$PHASH2"
+# validation greps for 'a + b', which this patch removes -> must roll back
+if "$BIN" workflow apply --repo "$REPO" "$ID2" --patch-hash "$PHASH2" --validate "grep -q 'a + b' src/calc.rs"; then
+  echo "FAIL: apply should have failed validation and rolled back"; exit 1
+fi
+grep -q 'a + b' src/calc.rs || { echo "FAIL: rollback did not restore tree"; exit 1; }
+echo "   rolled back to 'a + b' (good)"
+
+echo "== 7. report =="
+"$BIN" workflow report --repo "$REPO" "$ID" | grep -q '"applied": true' || { echo "FAIL: report missing applied=true"; exit 1; }
+
+echo "APPROVAL-CONTROLLED PATCH SMOKE PASSED"

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod repo_workbench;
 pub mod serve;
 pub mod templates;
 pub mod work;
+pub mod workflow;

--- a/src/cli/commands/workflow.rs
+++ b/src/cli/commands/workflow.rs
@@ -1,0 +1,170 @@
+//! CLI for the approval-controlled patch workflow.
+//!
+//! Drives `prometheos_lite::workflow` end to end:
+//! propose -> dry-run -> approve -> apply -> report.
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+use prometheos_lite::workflow::{self, AuthorityLevel};
+
+#[derive(Debug, Parser)]
+pub struct WorkflowCommand {
+    #[command(subcommand)]
+    command: WorkflowSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum WorkflowSubcommand {
+    /// Analyze the repo, lock scope, and record a proposed patch artifact.
+    Propose {
+        /// Repository root to operate on.
+        #[arg(long)]
+        repo: PathBuf,
+        /// Goal description.
+        #[arg(short, long)]
+        goal: String,
+        /// Authority level: review | propose | assist | execute.
+        #[arg(long, default_value = "propose")]
+        authority: String,
+        /// Path to a unified-diff patch file to propose.
+        #[arg(long)]
+        patch: PathBuf,
+        /// Allowed repo-relative path prefixes (repeatable).
+        #[arg(long = "allowed")]
+        allowed: Vec<String>,
+        /// Forbidden repo-relative path prefixes (repeatable).
+        #[arg(long = "forbidden")]
+        forbidden: Vec<String>,
+        /// Allow dependency-manifest changes (Cargo.toml, package.json, ...).
+        #[arg(long)]
+        allow_deps: bool,
+        /// Maximum changed files before blocking.
+        #[arg(long)]
+        max_files: Option<usize>,
+        /// Maximum changed lines before blocking.
+        #[arg(long)]
+        max_lines: Option<usize>,
+    },
+    /// Validate the proposal in an isolated Git worktree.
+    DryRun {
+        /// Repository root.
+        #[arg(long)]
+        repo: PathBuf,
+        /// Workflow id returned by `propose`.
+        id: String,
+        /// Optional validation command (run inside the worktree via `sh -c`).
+        #[arg(long)]
+        validate: Option<String>,
+    },
+    /// Record explicit approval for the proposal's patch hash.
+    Approve {
+        /// Repository root.
+        #[arg(long)]
+        repo: PathBuf,
+        /// Workflow id.
+        id: String,
+        /// Patch hash to approve (must match the proposal).
+        #[arg(long = "patch-hash")]
+        patch_hash: String,
+        /// Approver identity.
+        #[arg(long, default_value = "operator")]
+        approver: String,
+    },
+    /// Apply the approved patch to the user's tree after checkpoint + scope re-check.
+    Apply {
+        /// Repository root.
+        #[arg(long)]
+        repo: PathBuf,
+        /// Workflow id.
+        id: String,
+        /// Patch hash (must match approval + proposal).
+        #[arg(long = "patch-hash")]
+        patch_hash: String,
+        /// Optional validation command (run in the repo via `sh -c`).
+        #[arg(long)]
+        validate: Option<String>,
+        /// Disable automatic rollback on validation failure.
+        #[arg(long)]
+        no_rollback: bool,
+    },
+    /// Print a JSON report for a workflow id.
+    Report {
+        /// Repository root.
+        #[arg(long)]
+        repo: PathBuf,
+        /// Workflow id.
+        id: String,
+    },
+}
+
+impl WorkflowCommand {
+    pub async fn execute(self) -> Result<()> {
+        match self.command {
+            WorkflowSubcommand::Propose {
+                repo,
+                goal,
+                authority,
+                patch,
+                allowed,
+                forbidden,
+                allow_deps,
+                max_files,
+                max_lines,
+            } => {
+                let authority: AuthorityLevel = authority.parse()?;
+                let patch_text = std::fs::read_to_string(&patch)
+                    .with_context(|| format!("cannot read patch file {}", patch.display()))?;
+                let id = workflow::propose(
+                    &repo,
+                    &goal,
+                    authority,
+                    &patch_text,
+                    &allowed,
+                    &forbidden,
+                    allow_deps,
+                    max_files,
+                    max_lines,
+                )?;
+                println!("{id}");
+                Ok(())
+            }
+            WorkflowSubcommand::DryRun { repo, id, validate } => {
+                let passed = workflow::dry_run(&repo, &id, validate.as_deref())?;
+                println!(
+                    "dry-run {} for {}",
+                    if passed { "PASSED" } else { "FAILED" },
+                    id
+                );
+                Ok(())
+            }
+            WorkflowSubcommand::Approve {
+                repo,
+                id,
+                patch_hash,
+                approver,
+            } => {
+                workflow::approve(&repo, &id, &patch_hash, &approver)?;
+                println!("approved {id}");
+                Ok(())
+            }
+            WorkflowSubcommand::Apply {
+                repo,
+                id,
+                patch_hash,
+                validate,
+                no_rollback,
+            } => {
+                workflow::apply(&repo, &id, &patch_hash, validate.as_deref(), !no_rollback)?;
+                println!("applied {id}");
+                Ok(())
+            }
+            WorkflowSubcommand::Report { repo, id } => {
+                let report = workflow::report(&repo, &id)?;
+                println!("{report}");
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,6 +35,8 @@ enum Commands {
     RepoWorkbench(commands::repo_workbench::RepoWorkbenchCommand),
     /// Manage domain templates
     Templates(commands::templates::TemplatesCommand),
+    /// Approval-controlled patch workflow: propose -> dry-run -> approve -> apply -> report
+    Workflow(commands::workflow::WorkflowCommand),
     /// Run provider/system/validation diagnostics
     Diagnostics(commands::diagnostics::DiagnosticsArgs),
 }
@@ -50,6 +52,7 @@ pub async fn run() -> anyhow::Result<()> {
         Commands::Work(cmd) => cmd.execute().await,
         Commands::RepoWorkbench(cmd) => cmd.execute().await,
         Commands::Templates(cmd) => cmd.execute().await,
+        Commands::Workflow(cmd) => cmd.execute().await,
         Commands::Diagnostics(args) => {
             commands::diagnostics::handle_diagnostics_command(args).await
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod runtime_policy;
 pub mod tools;
 pub mod utils;
 pub mod work;
+pub mod workflow;
 
 // Legacy modules - deprecated in favor of flow-centric architecture
 // Use the "legacy" feature flag to enable these for backward compatibility

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -1,0 +1,571 @@
+//! Approval-controlled patch workflow.
+//!
+//! Implements the safe path from repository understanding to a verified patch:
+//!
+//! ```text
+//! review -> propose -> isolated dry-run -> explicit approval -> checkpoint -> apply -> validate -> report
+//! ```
+//!
+//! This module is intentionally self-contained. It drives Git directly (worktrees for
+//! dry-run, `git apply` for application, checkpoint branches + reverse-apply for rollback)
+//! and enforces a [`ScopeContract`] before any write to the user's tree.
+//!
+//! No model or provider is required here: the proposed patch is supplied by the caller
+//! (or generated upstream by a `PatchProvider`). The safety value is the gating, not the
+//! generation.
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityLevel {
+    /// Read and report only.
+    Review,
+    /// Generate plan + patch artifact. No application.
+    Propose,
+    /// Dry-run and apply only after explicit approval.
+    Assist,
+    /// Bounded execution under approved policy.
+    Execute,
+}
+
+impl AuthorityLevel {
+    /// Only `Assist`/`Execute` may apply patches to the user's tree.
+    pub fn can_apply(self) -> bool {
+        matches!(self, AuthorityLevel::Assist | AuthorityLevel::Execute)
+    }
+}
+
+impl FromStr for AuthorityLevel {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "review" => Ok(AuthorityLevel::Review),
+            "propose" => Ok(AuthorityLevel::Propose),
+            "assist" => Ok(AuthorityLevel::Assist),
+            "execute" => Ok(AuthorityLevel::Execute),
+            other => {
+                bail!("unknown authority level: {other} (expected review|propose|assist|execute)")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for AuthorityLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            AuthorityLevel::Review => "review",
+            AuthorityLevel::Propose => "propose",
+            AuthorityLevel::Assist => "assist",
+            AuthorityLevel::Execute => "execute",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Locked scope for a workflow run. Immutable once proposed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopeContract {
+    pub goal: String,
+    pub authority: AuthorityLevel,
+    /// Allowed path prefixes (repo-relative). Empty means "any path under the repo".
+    pub allowed_paths: Vec<String>,
+    /// Forbidden path prefixes. Always block.
+    pub forbidden_paths: Vec<String>,
+    /// Whether dependency-manifest changes (Cargo.toml, package.json, ...) are permitted.
+    pub allow_dependency_changes: bool,
+    /// Optional maximum number of changed files.
+    pub max_files_changed: Option<usize>,
+    /// Optional maximum total changed lines.
+    pub max_lines_changed: Option<usize>,
+}
+
+/// Explicit approval record. The patch hash must match the approved proposal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApprovalRecord {
+    pub approver: String,
+    pub approved_at: String,
+    pub patch_hash: String,
+}
+
+/// Persisted proposal artifact. Lives at `<repo>/.prometheos/workflow/<id>/proposal.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposalArtifact {
+    pub id: String,
+    pub repo: String,
+    pub base_sha: String,
+    pub goal: String,
+    pub authority: AuthorityLevel,
+    pub scope: ScopeContract,
+    /// Full unified-diff text.
+    pub patch: String,
+    pub patch_hash: String,
+    pub changed_files: Vec<String>,
+    pub added_lines: usize,
+    pub removed_lines: usize,
+    pub approved: Option<ApprovalRecord>,
+    pub dry_run_passed: Option<bool>,
+    pub applied: Option<bool>,
+}
+
+/// Run `git` in `repo` and return stdout, failing on non-zero exit.
+fn run_git(repo: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .context("failed to execute git")?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git {} failed: {}", args.join(" "), stderr.trim())
+    }
+}
+
+fn hash_str(s: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Dependency-manifest filenames whose change requires explicit scope permission.
+fn is_dependency_file(path: &str) -> bool {
+    matches!(
+        path.trim_start_matches("./").rsplit('/').next(),
+        Some("Cargo.toml")
+            | Some("Cargo.lock")
+            | Some("package.json")
+            | Some("package-lock.json")
+            | Some("yarn.lock")
+            | Some("pnpm-lock.yaml")
+            | Some("pom.xml")
+            | Some("build.gradle")
+            | Some("requirements.txt")
+            | Some("poetry.lock")
+            | Some("go.mod")
+            | Some("go.sum")
+    )
+}
+
+/// Parse changed file paths and added/removed line counts from a unified diff.
+fn analyze_diff(patch: &str) -> (Vec<String>, usize, usize) {
+    let mut files = Vec::new();
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    for line in patch.lines() {
+        if let Some(rest) = line.strip_prefix("+++ b/") {
+            let f = rest.trim().to_string();
+            if !f.is_empty() && f != "/dev/null" && !files.contains(&f) {
+                files.push(f.clone());
+            }
+        } else if let Some(rest) = line.strip_prefix("--- a/") {
+            let f = rest.trim().to_string();
+            if !f.is_empty() && f != "/dev/null" && !files.contains(&f) {
+                files.push(f.clone());
+            }
+        } else if line.starts_with('+') && !line.starts_with("+++") {
+            added += 1;
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            removed += 1;
+        }
+    }
+    (files, added, removed)
+}
+
+fn path_matches_filter(path: &str, filter: &str) -> bool {
+    if filter.is_empty() {
+        return true;
+    }
+    let clean = path.trim_start_matches("./");
+    // Normalize glob-ish filters: "src/**" or "src/*" collapse to the "src" base.
+    let base = filter
+        .trim_end_matches("/**")
+        .trim_end_matches("**")
+        .trim_end_matches('*')
+        .trim_end_matches('/');
+    clean == base || clean.starts_with(&format!("{base}/"))
+}
+
+fn scope_violations(scope: &ScopeContract, files: &[String]) -> Vec<String> {
+    let mut violations = Vec::new();
+    for f in files {
+        for forbidden in &scope.forbidden_paths {
+            if path_matches_filter(f, forbidden) {
+                violations.push(format!("forbidden path changed: {f} (matches {forbidden})"));
+            }
+        }
+        if !scope.allow_dependency_changes && is_dependency_file(f) {
+            violations.push(format!("dependency file changed without permission: {f}"));
+        }
+        if !scope.allowed_paths.is_empty() {
+            let allowed = scope
+                .allowed_paths
+                .iter()
+                .any(|a| path_matches_filter(f, a));
+            if !allowed {
+                violations.push(format!("path outside approved scope: {f}"));
+            }
+        }
+    }
+    violations
+}
+
+fn workflow_dir(repo: &Path, id: &str) -> PathBuf {
+    repo.join(".prometheos").join("workflow").join(id)
+}
+
+fn load_proposal(repo: &Path, id: &str) -> Result<ProposalArtifact> {
+    let path = workflow_dir(repo, id).join("proposal.json");
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("cannot read proposal {id} at {}", path.display()))?;
+    serde_json::from_str(&text).context("failed to parse proposal artifact")
+}
+
+fn save_proposal(repo: &Path, proposal: &ProposalArtifact) -> Result<()> {
+    let dir = workflow_dir(repo, &proposal.id);
+    std::fs::create_dir_all(&dir).context("failed to create workflow dir")?;
+    let text = serde_json::to_string_pretty(proposal).context("failed to serialize proposal")?;
+    std::fs::write(dir.join("proposal.json"), text).context("failed to write proposal")?;
+    Ok(())
+}
+
+fn now_iso() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // RFC3339-ish; precision to seconds is enough for an approval record.
+    chrono::DateTime::from_timestamp(secs as i64, 0)
+        .map(|d| d.to_rfc3339())
+        .unwrap_or_else(|| secs.to_string())
+}
+
+/// Propose a patch. Validates scope immediately and persists a proposal artifact.
+/// Returns the workflow id.
+pub fn propose(
+    repo: &Path,
+    goal: &str,
+    authority: AuthorityLevel,
+    patch: &str,
+    allowed_paths: &[String],
+    forbidden_paths: &[String],
+    allow_dependency_changes: bool,
+    max_files_changed: Option<usize>,
+    max_lines_changed: Option<usize>,
+) -> Result<String> {
+    if !is_git_repo(repo) {
+        bail!("not a git repository: {}", repo.display());
+    }
+    let base_sha = run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string();
+    let patch_hash = hash_str(patch);
+    let (changed_files, added, removed) = analyze_diff(patch);
+
+    let scope = ScopeContract {
+        goal: goal.to_string(),
+        authority,
+        allowed_paths: allowed_paths.to_vec(),
+        forbidden_paths: forbidden_paths.to_vec(),
+        allow_dependency_changes,
+        max_files_changed,
+        max_lines_changed,
+    };
+
+    let mut violations = scope_violations(&scope, &changed_files);
+    if let Some(max) = max_files_changed
+        && changed_files.len() > max
+    {
+        violations.push(format!(
+            "changed {} files exceeds budget of {max}",
+            changed_files.len()
+        ));
+    }
+    if let Some(max) = max_lines_changed
+        && added + removed > max
+    {
+        violations.push(format!(
+            "changed {} lines exceeds budget of {max}",
+            added + removed
+        ));
+    }
+    if !violations.is_empty() {
+        bail!("scope check failed:\n- {}", violations.join("\n- "));
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let proposal = ProposalArtifact {
+        id: id.clone(),
+        repo: repo.display().to_string(),
+        base_sha,
+        goal: goal.to_string(),
+        authority,
+        scope,
+        patch: patch.to_string(),
+        patch_hash,
+        changed_files,
+        added_lines: added,
+        removed_lines: removed,
+        approved: None,
+        dry_run_passed: None,
+        applied: None,
+    };
+    save_proposal(repo, &proposal)?;
+    Ok(id)
+}
+
+/// Run an isolated dry-run in a detached Git worktree: validate with `git apply --check`,
+/// apply, optionally run a validation command, then remove the worktree.
+pub fn dry_run(repo: &Path, id: &str, validation: Option<&str>) -> Result<bool> {
+    let mut proposal = load_proposal(repo, id)?;
+    let wt_root = std::env::temp_dir().join(format!("prometheos-dry-run-{id}"));
+    // Clean any stale state for this path, then prune orphaned worktree registrations.
+    let _ = run_git(
+        repo,
+        &["worktree", "remove", "--force", wt_root.to_str().unwrap()],
+    );
+    let _ = std::fs::remove_dir_all(&wt_root);
+    let _ = run_git(repo, &["worktree", "prune"]);
+
+    let patch_file = std::env::temp_dir().join(format!("prometheos-patch-{id}.patch"));
+    std::fs::write(&patch_file, &proposal.patch).context("failed to write patch file")?;
+
+    // Create a detached worktree at base sha. `git worktree add` creates the dir itself,
+    // so we must not pre-create it.
+    run_git(
+        repo,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            wt_root.to_str().unwrap(),
+            &proposal.base_sha,
+        ],
+    )
+    .context("failed to create dry-run worktree")?;
+
+    let result: Result<bool> = (|| {
+        run_git(
+            &wt_root,
+            &["apply", "--check", patch_file.to_str().unwrap()],
+        )
+        .context("patch does not apply cleanly (--check failed)")?;
+        run_git(&wt_root, &["apply", patch_file.to_str().unwrap()])
+            .context("patch application failed in dry-run")?;
+
+        if let Some(cmd) = validation {
+            let status = Command::new("sh")
+                .arg("-c")
+                .arg(cmd)
+                .current_dir(&wt_root)
+                .status()
+                .context("failed to run validation command")?;
+            if !status.success() {
+                bail!("validation command failed in dry-run");
+            }
+        }
+        Ok(true)
+    })();
+
+    let _ = run_git(
+        repo,
+        &["worktree", "remove", "--force", wt_root.to_str().unwrap()],
+    );
+    let _ = std::fs::remove_dir_all(&wt_root);
+    let _ = std::fs::remove_file(&patch_file);
+
+    match result {
+        Ok(_) => {
+            proposal.dry_run_passed = Some(true);
+            save_proposal(repo, &proposal)?;
+            Ok(true)
+        }
+        Err(e) => {
+            proposal.dry_run_passed = Some(false);
+            save_proposal(repo, &proposal)?;
+            Err(e)
+        }
+    }
+}
+
+/// Record explicit approval. The supplied patch hash must match the proposal.
+pub fn approve(repo: &Path, id: &str, patch_hash: &str, approver: &str) -> Result<()> {
+    let mut proposal = load_proposal(repo, id)?;
+    if proposal.patch_hash != patch_hash {
+        bail!(
+            "approval patch hash mismatch: approved={patch_hash} proposal={}",
+            proposal.patch_hash
+        );
+    }
+    proposal.approved = Some(ApprovalRecord {
+        approver: approver.to_string(),
+        approved_at: now_iso(),
+        patch_hash: patch_hash.to_string(),
+    });
+    save_proposal(repo, &proposal)?;
+    Ok(())
+}
+
+/// Apply the approved patch to the user's tree. Refuses on dirty trees, requires a
+/// matching approval, enforces scope, creates a checkpoint branch, and rolls back on
+/// validation failure when requested.
+pub fn apply(
+    repo: &Path,
+    id: &str,
+    patch_hash: &str,
+    validation: Option<&str>,
+    rollback_on_failure: bool,
+) -> Result<()> {
+    let mut proposal = load_proposal(repo, id)?;
+
+    if !proposal.authority.can_apply() {
+        bail!(
+            "authority '{}' cannot apply patches; require assist/execute",
+            proposal.authority
+        );
+    }
+    let approval = proposal
+        .approved
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("apply blocked: no approval recorded"))?;
+    if approval.patch_hash != patch_hash || proposal.patch_hash != patch_hash {
+        bail!("apply blocked: approval/patch hash mismatch");
+    }
+
+    // Re-check scope in case the artifact was tampered with.
+    let violations = scope_violations(&proposal.scope, &proposal.changed_files);
+    if !violations.is_empty() {
+        bail!(
+            "apply blocked: scope violation\n- {}",
+            violations.join("\n- ")
+        );
+    }
+
+    // Refuse to touch a dirty working tree (do not silently stash user work).
+    // The workflow's own `.prometheos/` metadata directory is ignored.
+    let status = run_git(repo, &["status", "--porcelain"])?;
+    let has_user_changes = status.lines().any(|line| {
+        let path = line.get(3..).unwrap_or("").trim();
+        !path.starts_with(".prometheos/")
+    });
+    if has_user_changes {
+        bail!("apply blocked: repository has uncommitted changes; stash or commit first");
+    }
+
+    let before_head = run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string();
+    let checkpoint_branch = format!("prometheos/checkpoint-{id}");
+    // Record checkpoint pointer (does not move HEAD).
+    run_git(repo, &["branch", &checkpoint_branch, &before_head])
+        .context("failed to create checkpoint branch")?;
+
+    let patch_file = std::env::temp_dir().join(format!("prometheos-apply-{id}.patch"));
+    std::fs::write(&patch_file, &proposal.patch).context("failed to write patch file")?;
+
+    let apply_result: Result<()> = (|| {
+        run_git(repo, &["apply", patch_file.to_str().unwrap()])
+            .context("patch application failed")?;
+        if let Some(cmd) = validation {
+            let status = Command::new("sh")
+                .arg("-c")
+                .arg(cmd)
+                .current_dir(repo)
+                .status()
+                .context("failed to run validation command")?;
+            if !status.success() {
+                bail!("validation command failed after apply");
+            }
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = apply_result {
+        if rollback_on_failure {
+            // Reverse the applied patch to restore the working tree.
+            let _ = run_git(repo, &["apply", "-R", patch_file.to_str().unwrap()]);
+            let _ = run_git(repo, &["branch", "-D", &checkpoint_branch]);
+            proposal.applied = Some(false);
+            save_proposal(repo, &proposal)?;
+            return Err(e.context("apply failed; rolled back working tree"));
+        }
+        proposal.applied = Some(false);
+        save_proposal(repo, &proposal)?;
+        return Err(e.context("apply failed; working tree left modified (rollback disabled)"));
+    }
+
+    proposal.applied = Some(true);
+    save_proposal(repo, &proposal)?;
+    Ok(())
+}
+
+/// Print a JSON report of the proposal.
+pub fn report(repo: &Path, id: &str) -> Result<String> {
+    let proposal = load_proposal(repo, id)?;
+    serde_json::to_string_pretty(&proposal).context("failed to serialize report")
+}
+
+/// True if `repo` is a Git repository.
+pub fn is_git_repo(repo: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(repo)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_diff_metadata() {
+        let patch = "\
+--- a/src/foo.rs
++++ b/src/foo.rs
+@@ -1,3 +1,3 @@
+ fn main() {
+-    let x = 1;
++    let x = 2;
+     println!(\"{x}\");
+ }
+";
+        let (files, added, removed) = analyze_diff(patch);
+        assert_eq!(files, vec!["src/foo.rs".to_string()]);
+        assert_eq!(added, 1);
+        assert_eq!(removed, 1);
+    }
+
+    #[test]
+    fn detects_forbidden_and_dependency_paths() {
+        let scope = ScopeContract {
+            goal: "g".into(),
+            authority: AuthorityLevel::Assist,
+            allowed_paths: vec![],
+            forbidden_paths: vec!["secrets/".into()],
+            allow_dependency_changes: false,
+            max_files_changed: None,
+            max_lines_changed: None,
+        };
+        let bad = scope_violations(&scope, &["secrets/key".into(), "Cargo.toml".into()]);
+        assert_eq!(bad.len(), 2);
+    }
+
+    #[test]
+    fn allows_open_scope() {
+        let scope = ScopeContract {
+            goal: "g".into(),
+            authority: AuthorityLevel::Assist,
+            allowed_paths: vec![],
+            forbidden_paths: vec![],
+            allow_dependency_changes: true,
+            max_files_changed: None,
+            max_lines_changed: None,
+        };
+        assert!(scope_violations(&scope, &["src/foo.rs".into()]).is_empty());
+    }
+}

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -40,6 +40,14 @@ impl AuthorityLevel {
     pub fn can_apply(self) -> bool {
         matches!(self, AuthorityLevel::Assist | AuthorityLevel::Execute)
     }
+
+    /// `Propose`/`Assist`/`Execute` may run an isolated dry-run. `Review` may not.
+    pub fn can_dry_run(self) -> bool {
+        matches!(
+            self,
+            AuthorityLevel::Propose | AuthorityLevel::Assist | AuthorityLevel::Execute
+        )
+    }
 }
 
 impl FromStr for AuthorityLevel {
@@ -217,6 +225,64 @@ fn scope_violations(scope: &ScopeContract, files: &[String]) -> Vec<String> {
     violations
 }
 
+/// Recompute the patch hash and diff metadata from the stored patch and ensure they
+/// match the recorded values. This catches accidental corruption and straightforward
+/// artifact tampering. It is NOT a cryptographic guarantee against a privileged local
+/// attacker, who can rewrite the whole artifact; remote/team approval will eventually
+/// need signed or server-held records.
+fn verify_proposal_integrity(proposal: &ProposalArtifact) -> Result<(Vec<String>, usize, usize)> {
+    let actual_hash = hash_str(&proposal.patch);
+    if actual_hash != proposal.patch_hash {
+        bail!("proposal integrity failure: patch content does not match stored hash");
+    }
+    let (files, added, removed) = analyze_diff(&proposal.patch);
+    if files != proposal.changed_files
+        || added != proposal.added_lines
+        || removed != proposal.removed_lines
+    {
+        bail!("proposal integrity failure: patch metadata does not match patch content");
+    }
+    Ok((files, added, removed))
+}
+
+/// Reject patch forms the narrow parser does not fully model (binary, renames, mode-only).
+/// New/deleted text files (handled via `/dev/null` headers) are allowed.
+fn reject_unsupported_patch(patch: &str) -> Result<()> {
+    let markers = [
+        "GIT binary patch",
+        "Binary files",
+        "rename from",
+        "rename to",
+        "similarity index",
+        "dissimilarity index",
+        "old mode",
+        "new mode",
+    ];
+    for m in markers {
+        if patch.contains(m) {
+            bail!(
+                "unsupported patch form rejected (contains '{m}'); only unified text diffs are supported"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// True if a local branch reference exists. `run_git` treats a nonzero exit as an error,
+/// so this is the non-panicking way to test existence.
+fn git_ref_exists(repo: &Path, branch: &str) -> bool {
+    run_git(
+        repo,
+        &[
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
+    )
+    .is_ok()
+}
+
 fn workflow_dir(repo: &Path, id: &str) -> PathBuf {
     repo.join(".prometheos").join("workflow").join(id)
 }
@@ -263,6 +329,7 @@ pub fn propose(
     if !is_git_repo(repo) {
         bail!("not a git repository: {}", repo.display());
     }
+    reject_unsupported_patch(patch)?;
     let base_sha = run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string();
     let patch_hash = hash_str(patch);
     let (changed_files, added, removed) = analyze_diff(patch);
@@ -323,6 +390,9 @@ pub fn propose(
 /// apply, optionally run a validation command, then remove the worktree.
 pub fn dry_run(repo: &Path, id: &str, validation: Option<&str>) -> Result<bool> {
     let mut proposal = load_proposal(repo, id)?;
+    if !proposal.authority.can_dry_run() {
+        bail!("authority '{}' cannot run a dry-run", proposal.authority);
+    }
     let wt_root = std::env::temp_dir().join(format!("prometheos-dry-run-{id}"));
     // Clean any stale state for this path, then prune orphaned worktree registrations.
     let _ = run_git(
@@ -393,9 +463,14 @@ pub fn dry_run(repo: &Path, id: &str, validation: Option<&str>) -> Result<bool> 
     }
 }
 
-/// Record explicit approval. The supplied patch hash must match the proposal.
+/// Record explicit approval. The supplied patch hash must match the proposal, the
+/// proposal must pass an isolated dry-run first, and artifact integrity is verified.
 pub fn approve(repo: &Path, id: &str, patch_hash: &str, approver: &str) -> Result<()> {
     let mut proposal = load_proposal(repo, id)?;
+    verify_proposal_integrity(&proposal)?;
+    if proposal.dry_run_passed != Some(true) {
+        bail!("approval blocked: proposal has not passed an isolated dry-run");
+    }
     if proposal.patch_hash != patch_hash {
         bail!(
             "approval patch hash mismatch: approved={patch_hash} proposal={}",
@@ -411,9 +486,18 @@ pub fn approve(repo: &Path, id: &str, patch_hash: &str, approver: &str) -> Resul
     Ok(())
 }
 
-/// Apply the approved patch to the user's tree. Refuses on dirty trees, requires a
-/// matching approval, enforces scope, creates a checkpoint branch, and rolls back on
-/// validation failure when requested.
+/// Apply the approved patch to the user's tree.
+///
+/// Enforces, in order: artifact integrity, a successful isolated dry-run, single-use,
+/// current HEAD == proposal `base_sha`, a non-existent checkpoint branch, scope against
+/// the *actual* patch, and a clean working tree (ignoring this workflow's own
+/// `.prometheos/` metadata). On validation failure it rolls back by reverse-applying and
+/// reports honestly; the checkpoint branch is preserved as recovery evidence.
+///
+/// Validation commands run through `sh -c` with the CLI process's OS permissions. They
+/// are NOT sandboxed (no process/network/secrets isolation). Remote or model-generated
+/// validation commands must never be executed automatically; future policy needs
+/// allowlisted command templates.
 pub fn apply(
     repo: &Path,
     id: &str,
@@ -422,6 +506,16 @@ pub fn apply(
     rollback_on_failure: bool,
 ) -> Result<()> {
     let mut proposal = load_proposal(repo, id)?;
+
+    let (actual_files, _, _) = verify_proposal_integrity(&proposal)?;
+
+    if proposal.dry_run_passed != Some(true) {
+        bail!("apply blocked: proposal has not passed an isolated dry-run");
+    }
+
+    if proposal.applied == Some(true) {
+        bail!("apply blocked: this proposal has already been applied");
+    }
 
     if !proposal.authority.can_apply() {
         bail!(
@@ -437,8 +531,19 @@ pub fn apply(
         bail!("apply blocked: approval/patch hash mismatch");
     }
 
-    // Re-check scope in case the artifact was tampered with.
-    let violations = scope_violations(&proposal.scope, &proposal.changed_files);
+    // Require the repository to be at the same commit the proposal was validated against.
+    let current_head = run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string();
+    if current_head != proposal.base_sha {
+        bail!(
+            "apply blocked: repository HEAD changed since proposal; expected {}, found {}. \
+             Create a new proposal or re-run against the current base.",
+            proposal.base_sha,
+            current_head
+        );
+    }
+
+    // Scope is enforced against the actual patch, not the stored file list.
+    let violations = scope_violations(&proposal.scope, &actual_files);
     if !violations.is_empty() {
         bail!(
             "apply blocked: scope violation\n- {}",
@@ -457,10 +562,12 @@ pub fn apply(
         bail!("apply blocked: repository has uncommitted changes; stash or commit first");
     }
 
-    let before_head = run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string();
+    // Preserve a checkpoint branch at the pre-apply HEAD as recovery evidence.
     let checkpoint_branch = format!("prometheos/checkpoint-{id}");
-    // Record checkpoint pointer (does not move HEAD).
-    run_git(repo, &["branch", &checkpoint_branch, &before_head])
+    if git_ref_exists(repo, &checkpoint_branch) {
+        bail!("apply blocked: checkpoint branch already exists: {checkpoint_branch}");
+    }
+    run_git(repo, &["branch", &checkpoint_branch, &current_head])
         .context("failed to create checkpoint branch")?;
 
     let patch_file = std::env::temp_dir().join(format!("prometheos-apply-{id}.patch"));
@@ -483,20 +590,35 @@ pub fn apply(
         Ok(())
     })();
 
-    if let Err(e) = apply_result {
+    if let Err(apply_error) = apply_result {
         if rollback_on_failure {
-            // Reverse the applied patch to restore the working tree.
-            let _ = run_git(repo, &["apply", "-R", patch_file.to_str().unwrap()]);
-            let _ = run_git(repo, &["branch", "-D", &checkpoint_branch]);
+            let rollback_result = run_git(repo, &["apply", "-R", patch_file.to_str().unwrap()]);
             proposal.applied = Some(false);
             save_proposal(repo, &proposal)?;
-            return Err(e.context("apply failed; rolled back working tree"));
+            match rollback_result {
+                Ok(_) => {
+                    return Err(
+                        apply_error.context("apply failed; working tree successfully rolled back")
+                    );
+                }
+                Err(rollback_error) => {
+                    return Err(anyhow::anyhow!(
+                        "apply failed and rollback also failed.\n\
+                         Apply error: {apply_error:#}\n\
+                         Rollback error: {rollback_error:#}\n\
+                         Checkpoint preserved at {checkpoint_branch}"
+                    ));
+                }
+            }
         }
         proposal.applied = Some(false);
         save_proposal(repo, &proposal)?;
-        return Err(e.context("apply failed; working tree left modified (rollback disabled)"));
+        return Err(
+            apply_error.context("apply failed; working tree left modified (rollback disabled)")
+        );
     }
 
+    // Checkpoint branch is intentionally preserved as recovery evidence.
     proposal.applied = Some(true);
     save_proposal(repo, &proposal)?;
     Ok(())
@@ -521,6 +643,79 @@ pub fn is_git_repo(repo: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(repo: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Build a temp git repo with one committed file (a boundary bug to fix).
+    fn temp_repo() -> (TempDir, PathBuf, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().to_path_buf();
+        git(&repo, &["init"]);
+        git(&repo, &["config", "user.email", "t@t"]);
+        git(&repo, &["config", "user.name", "t"]);
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+        std::fs::write(
+            repo.join("src/calc.rs"),
+            "pub fn add(a: i32, b: i32) -> i32 { a - b }\n",
+        )
+        .unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        let base = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        (dir, repo, base)
+    }
+
+    fn patch_for(file: &str, old: &str, new: &str) -> String {
+        format!("--- a/{file}\n+++ b/{file}\n@@ -1 +1 @@\n-{old}\n+{new}\n")
+    }
+
+    fn good_patch() -> String {
+        patch_for(
+            "src/calc.rs",
+            "pub fn add(a: i32, b: i32) -> i32 { a - b }",
+            "pub fn add(a: i32, b: i32) -> i32 { a + b }",
+        )
+    }
+
+    fn phash(patch: &str) -> String {
+        hash_str(patch)
+    }
+
+    fn propose_ok(repo: &Path, authority: AuthorityLevel) -> String {
+        propose(
+            repo,
+            "fix",
+            authority,
+            &good_patch(),
+            &["src/**".to_string()],
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    // --- existing structural tests ---
 
     #[test]
     fn parses_diff_metadata() {
@@ -567,5 +762,366 @@ mod tests {
             max_lines_changed: None,
         };
         assert!(scope_violations(&scope, &["src/foo.rs".into()]).is_empty());
+    }
+
+    // --- gate tests ---
+
+    #[test]
+    fn apply_rejects_without_approval() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn approve_rejects_without_dry_run() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        // No dry-run ran, so approval must be refused.
+        assert!(approve(&repo, &id, &phash(&good_patch()), "op").is_err());
+    }
+
+    #[test]
+    fn apply_rejects_without_dry_run() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        // The public API cannot reach "approved but no passing dry-run", so craft the
+        // persisted artifact to exercise the apply-time dry-run gate directly.
+        let mut proposal = load_proposal(&repo, &id).unwrap();
+        proposal.approved = Some(ApprovalRecord {
+            approver: "op".into(),
+            approved_at: now_iso(),
+            patch_hash: phash(&good_patch()),
+        });
+        proposal.dry_run_passed = None;
+        save_proposal(&repo, &proposal).unwrap();
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn apply_rejects_after_failed_dry_run() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        // Validation fails during dry-run -> dry_run_passed == false.
+        assert!(dry_run(&repo, &id, Some("grep -q 'NOPE' src/calc.rs")).is_err());
+        assert!(approve(&repo, &id, &phash(&good_patch()), "op").is_err());
+    }
+
+    #[test]
+    fn apply_rejects_after_head_changed() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Move HEAD away from the validated base.
+        std::fs::write(repo.join("unrelated.rs"), "fn u() {}\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "move head"]);
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn approval_wrong_hash_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        assert!(approve(&repo, &id, "deadbeef", "op").is_err());
+    }
+
+    #[test]
+    fn stored_patch_tamper_after_approval_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Edit the stored patch but leave the recorded hash unchanged -> integrity fails.
+        let path = repo
+            .join(".prometheos")
+            .join("workflow")
+            .join(&id)
+            .join("proposal.json");
+        let mut doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        doc["patch"] = serde_json::Value::String(patch_for(
+            "src/calc.rs",
+            "pub fn add(a: i32, b: i32) -> i32 { a - b }",
+            "pub fn add(a: i32, b: i32) -> i32 { a * b }",
+        ));
+        std::fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn stored_metadata_tamper_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        let path = repo
+            .join(".prometheos")
+            .join("workflow")
+            .join(&id)
+            .join("proposal.json");
+        let mut doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        doc["changed_files"] = serde_json::Value::Array(vec![]);
+        std::fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn path_outside_allowed_scope_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let patch = patch_for("other/x.rs", "old", "new");
+        let res = propose(
+            &repo,
+            "fix",
+            AuthorityLevel::Assist,
+            &patch,
+            &["src/**".to_string()],
+            &[],
+            false,
+            None,
+            None,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn forbidden_overrides_allowed_parent() {
+        let (_d, repo, _base) = temp_repo();
+        let patch = patch_for("src/secrets/k.rs", "old", "new");
+        let res = propose(
+            &repo,
+            "fix",
+            AuthorityLevel::Assist,
+            &patch,
+            &["src/**".to_string()],
+            &["src/secrets/".to_string()],
+            false,
+            None,
+            None,
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn dependency_rejected_unless_allowed() {
+        let (_d, repo, _base) = temp_repo();
+        let patch = patch_for("Cargo.toml", "version = \"0.1\"", "version = \"0.2\"");
+        assert!(
+            propose(
+                &repo,
+                "fix",
+                AuthorityLevel::Assist,
+                &patch,
+                &[],
+                &[],
+                false,
+                None,
+                None
+            )
+            .is_err()
+        );
+        // Allowed: proposal succeeds.
+        assert!(
+            propose(
+                &repo,
+                "fix",
+                AuthorityLevel::Assist,
+                &patch,
+                &[],
+                &[],
+                true,
+                None,
+                None
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn file_budget_enforced() {
+        let (_d, repo, _base) = temp_repo();
+        // Zero files allowed but the patch touches one.
+        assert!(
+            propose(
+                &repo,
+                "fix",
+                AuthorityLevel::Assist,
+                &good_patch(),
+                &["src/**".to_string()],
+                &[],
+                false,
+                Some(0),
+                None,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn line_budget_enforced() {
+        let (_d, repo, _base) = temp_repo();
+        assert!(
+            propose(
+                &repo,
+                "fix",
+                AuthorityLevel::Assist,
+                &good_patch(),
+                &["src/**".to_string()],
+                &[],
+                false,
+                None,
+                Some(0),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn dirty_tree_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Untracked user change (not under .prometheos).
+        std::fs::write(repo.join("scratch.rs"), "fn s() {}\n").unwrap();
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn prometheos_metadata_not_dirty() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Only .prometheos/ is untracked; apply must not treat it as dirty.
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_ok());
+    }
+
+    #[test]
+    fn validation_failure_rolls_back_and_preserves_checkpoint() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Apply a different patch whose validation (grep 'a + b') fails.
+        let bad_patch = patch_for(
+            "src/calc.rs",
+            "pub fn add(a: i32, b: i32) -> i32 { a - b }",
+            "pub fn add(a: i32, b: i32) -> i32 { a * b }",
+        );
+        let bad_id = propose(
+            &repo,
+            "change",
+            AuthorityLevel::Assist,
+            &bad_patch,
+            &["src/**".to_string()],
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+        // Dry-run validation passes (the patch produces `a * b`); apply validation fails.
+        dry_run(&repo, &bad_id, Some("grep -q 'a \\* b' src/calc.rs")).unwrap();
+        approve(&repo, &bad_id, &phash(&bad_patch), "op").unwrap();
+        assert!(
+            apply(
+                &repo,
+                &bad_id,
+                &phash(&bad_patch),
+                Some("grep -q 'a + b' src/calc.rs"),
+                true
+            )
+            .is_err()
+        );
+        // Tree reverted to original buggy form.
+        let content = std::fs::read_to_string(repo.join("src/calc.rs")).unwrap();
+        assert!(
+            content.contains("a - b"),
+            "tree was not rolled back: {content}"
+        );
+        // Checkpoint branch preserved as recovery evidence.
+        assert!(git_ref_exists(
+            &repo,
+            &format!("prometheos/checkpoint-{bad_id}")
+        ));
+    }
+
+    #[test]
+    fn rollback_failure_reported_and_checkpoint_preserved() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Validation command fails (to trigger rollback) but mutates the changed line
+        // so that reverse-apply can no longer match, forcing a rollback failure.
+        let result = apply(
+            &repo,
+            &id,
+            &phash(&good_patch()),
+            Some("sed -i 's/a + b/a + b EXTRA/' src/calc.rs; false"),
+            true,
+        );
+        assert!(result.is_err());
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("rollback also failed"),
+            "expected honest rollback-failure report, got: {msg}"
+        );
+        // Checkpoint must remain when rollback fails (do not delete recovery data).
+        assert!(git_ref_exists(
+            &repo,
+            &format!("prometheos/checkpoint-{id}")
+        ));
+    }
+
+    #[test]
+    fn reapply_already_applied_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Assist);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_ok());
+        // Second application of the same proposal is refused.
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+        // And the checkpoint branch remains.
+        assert!(git_ref_exists(
+            &repo,
+            &format!("prometheos/checkpoint-{id}")
+        ));
+    }
+
+    #[test]
+    fn propose_authority_cannot_apply() {
+        let (_d, repo, _base) = temp_repo();
+        let id = propose_ok(&repo, AuthorityLevel::Propose);
+        dry_run(&repo, &id, Some("grep -q 'a + b' src/calc.rs")).unwrap();
+        approve(&repo, &id, &phash(&good_patch()), "op").unwrap();
+        // Propose authority cannot apply.
+        assert!(apply(&repo, &id, &phash(&good_patch()), None, true).is_err());
+    }
+
+    #[test]
+    fn unsupported_patch_rejected() {
+        let (_d, repo, _base) = temp_repo();
+        let binary = "--- a/img.png\n+++ b/img.png\nGIT binary patch\nliteral 0\nH4sIAAAAAAAA\n";
+        assert!(
+            propose(
+                &repo,
+                "fix",
+                AuthorityLevel::Assist,
+                binary,
+                &["src/**".to_string()],
+                &[],
+                false,
+                None,
+                None,
+            )
+            .is_err()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements the approval-controlled patch workflow (issue #76): the safe path from repository understanding to a verified patch — `review -> propose -> isolated dry-run -> explicit approval -> checkpoint -> apply -> validate -> report`.

New self-contained module `src/workflow` plus a `prometheos workflow` CLI (`propose` / `dry-run` / `approve` / `apply` / `report`). It drives Git directly: isolated dry-run in a detached worktree, scope enforcement via a `ScopeContract` (allowed/forbidden paths, dependency-manifest guard, file/line budgets), explicit approval gated by patch hash, a checkpoint branch before apply, and reverse-apply rollback on validation failure. A golden-path smoke (`scripts/approval-controlled-patch-smoke.sh`) exercises the full flow end-to-end and passes locally. A CI job runs it.

## Mode

Task Mode (single feature PR; contract is issue #76).

## Approved scope

Authorized by operator direction to build the product path (issue #76) in one PR: implement the approval-controlled patch workflow reusing existing Git/`PathGuard`/patch primitives.

## Tasks completed

- `src/workflow/mod.rs`: `AuthorityLevel`, `ScopeContract`, `ApprovalRecord`, `ProposalArtifact`; `propose` / `dry_run` / `approve` / `apply` / `report`; scope checks, worktree dry-run, checkpoint + rollback.
- `src/cli/commands/workflow.rs` + `cli/mod.rs` + `cli/commands/mod.rs` + `lib.rs`: `prometheos workflow` subcommand.
- `scripts/approval-controlled-patch-smoke.sh`: golden-path smoke (propose, refuse-without-approval, dry-run, approve, apply, rollback).
- `.github/workflows/ci.yml`: `approval-controlled-patch-smoke` job (separate from `rust-checks`).

## Files changed

- `src/workflow/mod.rs` (new) — workflow engine.
- `src/cli/commands/workflow.rs` (new) — CLI.
- `src/cli/mod.rs`, `src/cli/commands/mod.rs`, `src/lib.rs` — register the command + module.
- `scripts/approval-controlled-patch-smoke.sh` (new) — golden path.
- `.github/workflows/ci.yml` — new CI job.

## Safety boundary

No stable alpha changes. No autonomous execution promotion. No new dependencies (uses `uuid`, `sha2`, `chrono`, `serde`, `anyhow` already present). No API/runtime behavior changes outside this feature. `prometheos work` behavior unchanged.

## Verification

- [x] `cargo fmt --check` — passed (locally).
- [x] `cargo check` — passed.
- [x] `cargo test --lib workflow` — 3 tests passed (diff parsing, scope violations, open scope).
- [x] `bash scripts/approval-controlled-patch-smoke.sh` — PASSED locally (propose -> refuse-without-approval -> dry-run -> approve -> apply -> rollback -> report).
- [x] `cargo build` — succeeded.
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — **this PR introduces no clippy errors/warnings** (verified: no `workflow`/`cli/commands/workflow` warnings). However, the full `cargo clippy -D warnings` currently FAILS on `main` due to a pre-existing strict-clippy regression (issue #75, `map_ignore_key` in existing `src/`); that is unrelated to this PR and must be fixed by #75 before `rust-checks` is green.
- [ ] Frontend build — not applicable (no frontend files touched).

## Known limitations

- Patch generation is out of scope here: the proposed patch is supplied (or produced upstream by a `PatchProvider`); this module gates and applies it safely.
- `apply` refuses on dirty trees (ignoring its own `.prometheos/` metadata) per the no-silent-stash rule; the smoke commits between applies to simulate user review.
- The new CI job will only be meaningful once #75 lands (it does not depend on `rust-checks`).

## Follow-ups

- Land issue #75 (restore strict clippy baseline) so `rust-checks` is green.
- Wire `propose` to an existing `PatchProvider` for model-backed patch generation.
- Add negative tests for scope drift and invalid approval hash to the CI job.

## Human review gate

Requires human approval before merge. Agents must not merge.
