### PR TITLE
feat(#78): generate governed proposals through PatchProvider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,24 @@ jobs:
       - name: Run approval-controlled patch workflow smoke
         run: bash scripts/approval-controlled-patch-smoke.sh
 
+  governed-provider-proposal-smoke:
+    name: Governed Provider-Proposal Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run governed provider-proposal smoke (offline, mock provider)
+        run: bash scripts/provider-governed-proposal-smoke.sh
+
+      - name: Provider governance tests
+        run: cargo test --test provider_governed_proposal_tests --quiet
+

--- a/scripts/provider-governed-proposal-smoke.sh
+++ b/scripts/provider-governed-proposal-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Governed provider-proposal smoke (#78).
+#
+# Builds the binary, creates a throwaway git repo, then drives the full safe path
+# through the provider-backed `generate` command using the deterministic offline
+# mock provider (no network, no API key):
+#
+#   generate (mock) -> dry-run -> approve -> apply -> validate -> report
+#
+# and proves:
+#   - the fixture is unchanged before approval
+#   - the generated patch is approved against its exact hash
+#   - provider output with a '..' traversal is rejected
+#   - provenance (no secrets) is present in the report
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps 2>/dev/null | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')"
+TARGET_DIR="${TARGET_DIR:-$ROOT/target}"
+case "$(uname -s)" in
+  MINGW* | MSYS* | CYGWIN*) BIN="$TARGET_DIR/debug/prometheos.exe" ;;
+  *) BIN="$TARGET_DIR/debug/prometheos" ;;
+esac
+[ -x "$BIN" ] || BIN="$TARGET_DIR/debug/prometheos"
+
+echo "Building prometheos..."
+cargo build --bin prometheos
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+mkdir -p "$REPO/src"
+cd "$REPO"
+git init -q
+git config user.email "smoke@prometheos.local"
+git config user.name "smoke"
+
+cat > src/main.rs <<'EOF'
+pub fn main() {}
+EOF
+git add -A
+git commit -qm "initial"
+
+echo "== 1. generate via deterministic mock provider (offline) =="
+OUT="$("$BIN" workflow generate --repo "$REPO" --goal "add generated file" --authority assist --allowed 'src/**' --provider mock)"
+echo "$OUT"
+ID="$(printf '%s' "$OUT" | head -n1 | tr -d '\r')"
+PHASH="$(printf '%s' "$OUT" | sed -n 's/^patch_hash=\(.*\)$/\1/p' | tr -d '\r')"
+[ -n "$ID" ] || { echo "FAIL: generate returned no id"; exit 1; }
+[ -n "$PHASH" ] || { echo "FAIL: generate returned no patch hash"; exit 1; }
+echo "   id=$ID patch_hash=$PHASH"
+
+echo "== 2. fixture unchanged before approval =="
+[ -f src/generated_patch.rs ] && { echo "FAIL: patch applied before approval"; exit 1; }
+grep -q 'pub fn main()' src/main.rs || { echo "FAIL: fixture source modified before approval"; exit 1; }
+echo "   fixture intact (good)"
+
+echo "== 3. rejected malicious provider output (path traversal) =="
+if PROMETHEOS_MOCK_MODE=traversal "$BIN" workflow generate --repo "$REPO" --goal g --authority assist --allowed 'src/**' --provider mock >/dev/null 2>&1; then
+  echo "FAIL: traversal provider output was accepted"; exit 1
+fi
+echo "   traversal rejected (good)"
+
+echo "== 4. dry-run passes in isolated worktree =="
+if ! "$BIN" workflow dry-run --repo "$REPO" "$ID" --validate "grep -q generated src/generated_patch.rs"; then
+  echo "FAIL: dry-run should pass"; exit 1
+fi
+
+echo "== 5. approve exact generated patch hash =="
+"$BIN" workflow approve --repo "$REPO" "$ID" --patch-hash "$PHASH"
+
+echo "== 6. apply + validate =="
+"$BIN" workflow apply --repo "$REPO" "$ID" --patch-hash "$PHASH" --validate "grep -q generated src/generated_patch.rs"
+grep -q generated src/generated_patch.rs || { echo "FAIL: tree not patched"; exit 1; }
+echo "   tree patched (good)"
+
+echo "== 7. report exposes provenance without secrets =="
+REPORT="$("$BIN" workflow report --repo "$REPO" "$ID")"
+echo "$REPORT" | grep -q '"implementation": "mock"' || { echo "FAIL: provenance missing"; exit 1; }
+echo "$REPORT" | grep -qi 'sk-\|authorization\|bearer' && { echo "FAIL: secret leaked into report"; exit 1; }
+echo "   provenance present, no secrets (good)"
+
+echo "GOVERNED PROVIDER-PROPOSAL SMOKE PASSED"

--- a/src/cli/commands/workflow.rs
+++ b/src/cli/commands/workflow.rs
@@ -15,7 +15,7 @@ use prometheos_lite::config::AppConfig;
 use prometheos_lite::harness::patch_provider::{
     MockProposalMode, MockProposalProvider, PatchProvider, PatchProviderContext, ProviderRegistry,
 };
-use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope, ProviderRouteInfo};
+use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope, ProviderRouteInfo, sanitize_provider_route};
 
 /// Map a string (e.g. from `PROMETHEOS_MOCK_MODE`) to a mock provider mode.
 fn provider_mode_from_str(s: &str) -> MockProposalMode {
@@ -267,7 +267,7 @@ impl WorkflowCommand {
                         let registry = ProviderRegistry::from_config(&config)?;
                         let route = ProviderRouteInfo {
                             model: Some(config.model.clone()),
-                            route: Some(config.base_url.clone()),
+                            route: sanitize_provider_route(&config.base_url),
                         };
                         (Box::new(registry), Some(route))
                     };

--- a/src/cli/commands/workflow.rs
+++ b/src/cli/commands/workflow.rs
@@ -2,12 +2,35 @@
 //!
 //! Drives `prometheos_lite::workflow` end to end:
 //! propose -> dry-run -> approve -> apply -> report.
+//!
+//! `generate` is the #78 slice: it routes a `PatchProvider` through the same
+//! governed path, so generated patches are treated as hostile input and pass
+//! through every existing gate.
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-use prometheos_lite::workflow::{self, AuthorityLevel};
+use prometheos_lite::config::AppConfig;
+use prometheos_lite::harness::patch_provider::{
+    MockProposalMode, MockProposalProvider, PatchProvider, PatchProviderContext, ProviderRegistry,
+};
+use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope, ProviderRouteInfo};
+
+/// Map a string (e.g. from `PROMETHEOS_MOCK_MODE`) to a mock provider mode.
+fn provider_mode_from_str(s: &str) -> MockProposalMode {
+    match s.to_ascii_lowercase().as_str() {
+        "outofscope" | "out_of_scope" => MockProposalMode::OutOfScope,
+        "forbidden" => MockProposalMode::Forbidden,
+        "dependency" => MockProposalMode::Dependency,
+        "absolute" => MockProposalMode::Absolute,
+        "traversal" => MockProposalMode::Traversal,
+        "malformed" => MockProposalMode::Malformed,
+        "empty" => MockProposalMode::Empty,
+        "failing" => MockProposalMode::Failing,
+        _ => MockProposalMode::Safe,
+    }
+}
 
 #[derive(Debug, Parser)]
 pub struct WorkflowCommand {
@@ -89,6 +112,45 @@ enum WorkflowSubcommand {
         #[arg(long)]
         no_rollback: bool,
     },
+    /// Generate a governed proposal through a PatchProvider (no patch file needed).
+    ///
+    /// The configured provider (or `--provider mock` for offline/deterministic runs)
+    /// produces candidate edits; those are rendered to a unified diff, treated as
+    /// hostile input, and routed through the same propose -> dry-run -> approve ->
+    /// apply -> report path as `propose`.
+    Generate {
+        /// Repository root to operate on.
+        #[arg(long)]
+        repo: PathBuf,
+        /// Goal description.
+        #[arg(short, long)]
+        goal: String,
+        /// Authority level: review | propose | assist | execute.
+        #[arg(long, default_value = "assist")]
+        authority: String,
+        /// Allowed repo-relative path prefixes (repeatable).
+        #[arg(long = "allowed")]
+        allowed: Vec<String>,
+        /// Forbidden repo-relative path prefixes (repeatable).
+        #[arg(long = "forbidden")]
+        forbidden: Vec<String>,
+        /// Allow dependency-manifest changes (Cargo.toml, package.json, ...).
+        #[arg(long)]
+        allow_deps: bool,
+        /// Maximum changed files before blocking.
+        #[arg(long)]
+        max_files: Option<usize>,
+        /// Maximum changed lines before blocking.
+        #[arg(long)]
+        max_lines: Option<usize>,
+        /// Validation command recorded with the proposal (run at dry-run/apply).
+        #[arg(long)]
+        validate: Option<String>,
+        /// Provider source: `config` (default) uses the configured provider, or
+        /// `mock` for the deterministic offline provider.
+        #[arg(long, default_value = "config")]
+        provider: String,
+    },
     /// Print a JSON report for a workflow id.
     Report {
         /// Repository root.
@@ -163,6 +225,66 @@ impl WorkflowCommand {
             WorkflowSubcommand::Report { repo, id } => {
                 let report = workflow::report(&repo, &id)?;
                 println!("{report}");
+                Ok(())
+            }
+            WorkflowSubcommand::Generate {
+                repo,
+                goal,
+                authority,
+                allowed,
+                forbidden,
+                allow_deps,
+                max_files,
+                max_lines,
+                validate,
+                provider,
+            } => {
+                let authority: AuthorityLevel = authority.parse()?;
+                let scope = GenerateScope {
+                    allowed_paths: allowed,
+                    forbidden_paths: forbidden,
+                    allow_dependency_changes: allow_deps,
+                    max_files_changed: max_files,
+                    max_lines_changed: max_lines,
+                };
+                let context = PatchProviderContext {
+                    task: goal.clone(),
+                    ..Default::default()
+                };
+
+                // Select the provider through the *existing* provider abstraction.
+                // No model is invoked directly here.
+                let (boxed, route_info): (Box<dyn PatchProvider>, Option<ProviderRouteInfo>) =
+                    if provider == "mock" {
+                        let mode = std::env::var("PROMETHEOS_MOCK_MODE")
+                            .map(|s| provider_mode_from_str(&s))
+                            .unwrap_or(MockProposalMode::Safe);
+                        (Box::new(MockProposalProvider::with_mode(mode)), None)
+                    } else {
+                        let config = AppConfig::load().context(
+                            "failed to load provider configuration; set PROMETHEOS_PROVIDER/MODEL/BASE_URL or use --provider mock",
+                        )?;
+                        let registry = ProviderRegistry::from_config(&config)?;
+                        let route = ProviderRouteInfo {
+                            model: Some(config.model.clone()),
+                            route: Some(config.base_url.clone()),
+                        };
+                        (Box::new(registry), Some(route))
+                    };
+
+                let result = workflow::generate_proposal(
+                    &repo,
+                    &goal,
+                    authority,
+                    boxed.as_ref(),
+                    context,
+                    &scope,
+                    route_info,
+                    validate,
+                )
+                .await?;
+                println!("{}", result.id);
+                println!("patch_hash={}", result.patch_hash);
                 Ok(())
             }
         }

--- a/src/harness/context_budget.rs
+++ b/src/harness/context_budget.rs
@@ -553,7 +553,7 @@ impl ContextBudget {
         }
 
         // Calculate averages
-        for (_, total) in avg_usage.iter_mut() {
+        for total in avg_usage.values_mut() {
             *total /= usage_history.len();
         }
 

--- a/src/harness/knowledge_cache.rs
+++ b/src/harness/knowledge_cache.rs
@@ -402,7 +402,7 @@ impl KnowledgeCacheManager {
         let caches = self.caches.read().await;
         let mut total_cleaned = 0;
 
-        for (_task_id, cache) in caches.iter() {
+        for cache in caches.values() {
             let keys = cache.keys(CacheScope::Task).await;
             let now = cache.now();
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -117,8 +117,9 @@ pub use observability::{
 pub use patch_applier::*;
 pub use patch_provider::{
     AggregatePatchProvider, AttemptOutcome, AttemptRecord, GenerateRequest, GenerateResponse,
-    HeuristicPatchProvider, LlmPatchProvider, PatchProvider, PatchProviderContext,
-    ProviderCandidate, ProviderCapabilities, RepairResponse, RiskEstimate,
+    HeuristicPatchProvider, LlmPatchProvider, MockProposalMode, MockProposalProvider,
+    PatchProvider, PatchProviderContext, ProviderCandidate, ProviderCapabilities, RepairResponse,
+    RiskEstimate,
 };
 pub use permissions::{
     Permission, PermissionCheck, PermissionGrant, PermissionLedger, PermissionScope,

--- a/src/harness/patch_provider.rs
+++ b/src/harness/patch_provider.rs
@@ -11,7 +11,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::harness::{
-    edit_protocol::{CreateFileEdit, EditOperation, SearchReplaceEdit, WholeFileEdit},
+    edit_protocol::{
+        CreateFileEdit, EditOperation, SearchReplaceEdit, UnifiedDiffEdit, WholeFileEdit,
+    },
     failure::{FailureDetails, FailureKind},
     repo_intelligence::RepoMap,
     review::ReviewIssue,
@@ -2425,5 +2427,137 @@ impl DeterministicPatchProvider {
         }
 
         Ok(with_imports)
+    }
+}
+
+/// Deterministic mock `PatchProvider` used for tests and offline CI.
+///
+/// This is a *mock implementation of the existing `PatchProvider` trait* (not a
+/// second provider abstraction). It emits fixed, controllable edits so the
+/// governed workflow can be exercised end to end without any network or model
+/// access. Construct it with [`MockProposalProvider::safe`] for the happy path,
+/// or [`MockProposalProvider::with_mode`] to exercise a specific negative case.
+pub struct MockProposalProvider {
+    mode: MockProposalMode,
+}
+
+/// Operating modes for [`MockProposalProvider`], covering the happy path and the
+/// hostile/negative cases the governed workflow must reject.
+#[derive(Debug, Clone, Copy)]
+pub enum MockProposalMode {
+    /// Create a new in-scope file (`src/generated_patch.rs`).
+    Safe,
+    /// Create a file outside the allowed scope (`other/x.rs`).
+    OutOfScope,
+    /// Create a file under a forbidden prefix (`src/secrets/k.rs`).
+    Forbidden,
+    /// Create a dependency manifest (`Cargo.toml`).
+    Dependency,
+    /// Create an absolute-path file (`/etc/passwd`).
+    Absolute,
+    /// Create a file using `..` traversal (`src/../escape.rs`).
+    Traversal,
+    /// Return a candidate whose patch is a malformed/unsupported diff.
+    Malformed,
+    /// Return a candidate with no edits (empty patch).
+    Empty,
+    /// Fail generation entirely (no artifact should be created).
+    Failing,
+}
+
+impl MockProposalProvider {
+    /// Create the happy-path mock provider (in-scope file creation).
+    pub fn safe() -> Self {
+        Self {
+            mode: MockProposalMode::Safe,
+        }
+    }
+
+    /// Create the mock provider in a specific mode.
+    pub fn with_mode(mode: MockProposalMode) -> Self {
+        Self { mode }
+    }
+}
+
+fn build_candidate(edits: Vec<EditOperation>, strategy: &str) -> ProviderCandidate {
+    ProviderCandidate {
+        edits,
+        source: "mock".to_string(),
+        strategy: strategy.to_string(),
+        confidence: 100,
+        reasoning: "deterministic mock provider".to_string(),
+        estimated_risk: RiskEstimate::Low,
+    }
+}
+
+#[async_trait]
+impl PatchProvider for MockProposalProvider {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    async fn generate(&self, _request: GenerateRequest) -> anyhow::Result<GenerateResponse> {
+        let edits = match self.mode {
+            MockProposalMode::Failing => {
+                anyhow::bail!("mock provider failure (injected)");
+            }
+            MockProposalMode::Empty => vec![],
+            MockProposalMode::Malformed => vec![EditOperation::UnifiedDiff(UnifiedDiffEdit {
+                diff: "--- a/x\n+++ b/x\nGIT binary patch\nliteral 0\nH4sIAAAAAAAA\n".to_string(),
+                target_file: None,
+            })],
+            MockProposalMode::Safe => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("src/generated_patch.rs"),
+                content: "pub fn generated() -> u32 {\n    1\n}\n".to_string(),
+                executable: None,
+            })],
+            MockProposalMode::OutOfScope => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("other/x.rs"),
+                content: "pub fn x() {}\n".to_string(),
+                executable: None,
+            })],
+            MockProposalMode::Forbidden => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("src/secrets/k.rs"),
+                content: "secret\n".to_string(),
+                executable: None,
+            })],
+            MockProposalMode::Dependency => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("Cargo.toml"),
+                content: "version = \"0.2\"\n".to_string(),
+                executable: None,
+            })],
+            MockProposalMode::Absolute => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("/etc/passwd"),
+                content: "root:x:0:0:root:/root:/bin/sh\n".to_string(),
+                executable: None,
+            })],
+            MockProposalMode::Traversal => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("src/../escape.rs"),
+                content: "pub fn escape() {}\n".to_string(),
+                executable: None,
+            })],
+        };
+
+        let candidates = if edits.is_empty() {
+            vec![]
+        } else {
+            vec![build_candidate(edits, "deterministic")]
+        };
+
+        Ok(GenerateResponse {
+            candidates,
+            generation_time_ms: 0,
+            provider_notes: Some(format!("mock provider mode: {:?}", self.mode)),
+        })
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            can_generate: true,
+            can_repair: false,
+            max_candidates: 1,
+            supported_operations: vec!["create_file".to_string()],
+            typical_latency_ms: 0,
+        }
     }
 }

--- a/src/harness/patch_provider.rs
+++ b/src/harness/patch_provider.rs
@@ -2459,6 +2459,12 @@ pub enum MockProposalMode {
     Traversal,
     /// Return a candidate whose patch is a malformed/unsupported diff.
     Malformed,
+    /// Return a candidate whose patch is plain text, not a unified diff.
+    PlainText,
+    /// Create a Windows drive-absolute file (`C:\...`).
+    WindowsDrive,
+    /// Create a UNC-path file (`\\server\share\...`).
+    Unc,
     /// Return a candidate with no edits (empty patch).
     Empty,
     /// Fail generation entirely (no artifact should be created).
@@ -2505,6 +2511,20 @@ impl PatchProvider for MockProposalProvider {
             MockProposalMode::Malformed => vec![EditOperation::UnifiedDiff(UnifiedDiffEdit {
                 diff: "--- a/x\n+++ b/x\nGIT binary patch\nliteral 0\nH4sIAAAAAAAA\n".to_string(),
                 target_file: None,
+            })],
+            MockProposalMode::PlainText => vec![EditOperation::UnifiedDiff(UnifiedDiffEdit {
+                diff: "this is a note, not a unified diff".to_string(),
+                target_file: None,
+            })],
+            MockProposalMode::WindowsDrive => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("C:\\windows\\system32\\evil.dll"),
+                content: "bad\n".to_string(),
+                executable: None,
+            })],
+            MockProposalMode::Unc => vec![EditOperation::CreateFile(CreateFileEdit {
+                file: PathBuf::from("\\\\server\\share\\evil.dll"),
+                content: "bad\n".to_string(),
+                executable: None,
             })],
             MockProposalMode::Safe => vec![EditOperation::CreateFile(CreateFileEdit {
                 file: PathBuf::from("src/generated_patch.rs"),

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -22,6 +22,9 @@ use std::process::Command;
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::harness::edit_protocol::{EditOperation, SearchReplaceEdit};
+use crate::harness::patch_provider::{GenerateRequest, PatchProvider, PatchProviderContext};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthorityLevel {
@@ -120,6 +123,47 @@ pub struct ProposalArtifact {
     pub approved: Option<ApprovalRecord>,
     pub dry_run_passed: Option<bool>,
     pub applied: Option<bool>,
+    /// Optional validation command recorded at generation time; used when a later
+    /// `dry-run`/`apply` does not supply its own.
+    pub validation_command: Option<String>,
+    /// Provider provenance for proposals generated through a `PatchProvider`.
+    pub provider_provenance: Option<ProviderProvenance>,
+}
+
+/// Provider provenance recorded with a governed proposal.
+///
+/// This answers *which* provider produced the patch, under *what* route/model, and
+/// binds the patch to its inputs and scope. It is deliberately free of any secret:
+/// no API key, authorization header, or token is ever persisted here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderProvenance {
+    /// Provider implementation name (e.g. "mock", "llm", "deterministic").
+    pub implementation: String,
+    /// Configured model name, when known (not a secret).
+    pub model: Option<String>,
+    /// Configured route/endpoint (e.g. base URL), when known (not a secret).
+    pub route: Option<String>,
+    /// Generation timestamp (RFC3339).
+    pub generated_at: String,
+    /// Work/trace identifier when available.
+    pub work_id: Option<String>,
+    /// Digest of the prompt/input (goal + requirements), not raw configuration.
+    pub input_digest: String,
+    /// Internally computed patch hash (mirrors `ProposalArtifact.patch_hash`).
+    pub patch_hash: String,
+    /// Base commit SHA the proposal was validated against.
+    pub base_sha: String,
+    /// Digest of the scope contract the proposal was validated against.
+    pub scope_digest: String,
+}
+
+/// Route/identity metadata used only to populate non-secret `ProviderProvenance`.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderRouteInfo {
+    /// Configured model name (not a secret).
+    pub model: Option<String>,
+    /// Configured route/endpoint (e.g. base URL), not a secret.
+    pub route: Option<String>,
 }
 
 /// Run `git` in `repo` and return stdout, failing on non-zero exit.
@@ -315,6 +359,10 @@ fn now_iso() -> String {
 
 /// Propose a patch. Validates scope immediately and persists a proposal artifact.
 /// Returns the workflow id.
+///
+/// This is the stable entry point used by the `workflow propose` CLI command and by
+/// tests. Provider-generated proposals should call [`generate_proposal`] (which routes
+/// through this same gating path) so that no parallel proposal path is introduced.
 pub fn propose(
     repo: &Path,
     goal: &str,
@@ -325,6 +373,37 @@ pub fn propose(
     allow_dependency_changes: bool,
     max_files_changed: Option<usize>,
     max_lines_changed: Option<usize>,
+) -> Result<String> {
+    propose_with_meta(
+        repo,
+        goal,
+        authority,
+        patch,
+        allowed_paths,
+        forbidden_paths,
+        allow_dependency_changes,
+        max_files_changed,
+        max_lines_changed,
+        None,
+        None,
+    )
+}
+
+/// Internal proposal constructor that accepts optional validation command and
+/// provider provenance. All gating lives here so the public `propose` and the
+/// provider-backed `generate_proposal` share identical behavior.
+fn propose_with_meta(
+    repo: &Path,
+    goal: &str,
+    authority: AuthorityLevel,
+    patch: &str,
+    allowed_paths: &[String],
+    forbidden_paths: &[String],
+    allow_dependency_changes: bool,
+    max_files_changed: Option<usize>,
+    max_lines_changed: Option<usize>,
+    validation_command: Option<String>,
+    provider_provenance: Option<ProviderProvenance>,
 ) -> Result<String> {
     if !is_git_repo(repo) {
         bail!("not a git repository: {}", repo.display());
@@ -381,9 +460,337 @@ pub fn propose(
         approved: None,
         dry_run_passed: None,
         applied: None,
+        validation_command,
+        provider_provenance,
     };
     save_proposal(repo, &proposal)?;
     Ok(id)
+}
+
+// ---------------------------------------------------------------------------
+// Provider-backed proposal generation (#78)
+//
+// A `PatchProvider` generates candidate edits. Those edits are rendered into a
+// unified diff and treated as *hostile* input (absolute/traversal rejection,
+// scope, unsupported-form, budget). The patch is then routed through
+// `propose_with_meta`, so every #77 gate (integrity, dry-run, approval-hash,
+// base-SHA, checkpoint, rollback) applies unchanged. No parallel proposal path
+// and no model invocation lives here.
+// ---------------------------------------------------------------------------
+
+/// Scope contract for a provider-backed generation request.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GenerateScope {
+    pub allowed_paths: Vec<String>,
+    pub forbidden_paths: Vec<String>,
+    pub allow_dependency_changes: bool,
+    pub max_files_changed: Option<usize>,
+    pub max_lines_changed: Option<usize>,
+}
+
+/// Result of a provider-backed generation request.
+#[derive(Debug, Clone)]
+pub struct GenerateResult {
+    pub id: String,
+    pub patch: String,
+    pub patch_hash: String,
+}
+
+/// Run `git` and return stdout, tolerating exit code 1 (which `git diff
+/// --no-index` uses to signal "files differ"). Other non-zero exits fail.
+fn run_git_capture(dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .context("failed to execute git")?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    if output.status.success() || output.status.code() == Some(1) {
+        Ok(stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git {} failed: {}", args.join(" "), stderr.trim())
+    }
+}
+
+/// Reject any patch path that escapes the repository: absolute paths (unix
+/// `/...`, Windows drive/UNC) or `..` traversal. `/dev/null` is always allowed.
+fn validate_patch_paths(repo: &Path, patch: &str) -> Result<()> {
+    for line in patch.lines() {
+        let path = match line
+            .strip_prefix("+++ b/")
+            .or_else(|| line.strip_prefix("--- a/"))
+        {
+            Some(rest) => rest.trim(),
+            None => continue,
+        };
+        if path.is_empty() || path == "/dev/null" {
+            continue;
+        }
+        if Path::new(path).is_absolute() || path.starts_with('/') {
+            bail!("rejected patch path is absolute and escapes the repo: {path}");
+        }
+        if path.split('/').any(|c| c == "..") {
+            bail!("rejected patch path contains '..' traversal: {path}");
+        }
+        if !repo.join(path).starts_with(repo) {
+            bail!("rejected patch path escapes the repo: {path}");
+        }
+    }
+    Ok(())
+}
+
+/// Normalize a provider-supplied file path to a repo-relative path, rejecting
+/// anything absolute or traversing outside the repository. First hostile-input
+/// gate applied to provider output.
+fn sanitize_repo_relative(file: &Path) -> Result<PathBuf> {
+    if file.is_absolute() || file.to_string_lossy().starts_with('/') {
+        bail!(
+            "rejected provider file path is absolute: {}",
+            file.display()
+        );
+    }
+    if file
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        bail!(
+            "rejected provider file path with '..' traversal: {}",
+            file.display()
+        );
+    }
+    if file.as_os_str().is_empty() {
+        bail!("rejected empty provider file path");
+    }
+    Ok(file.to_path_buf())
+}
+
+/// Render a single provider edit into a unified-diff fragment. The edit's file
+/// path is validated as hostile input first.
+fn render_single_edit(repo: &Path, edit: &EditOperation) -> Result<String> {
+    match edit {
+        EditOperation::UnifiedDiff(u) => {
+            validate_patch_paths(repo, &u.diff)?;
+            Ok(u.diff.clone())
+        }
+        EditOperation::CreateFile(c) => {
+            let rel = sanitize_repo_relative(&c.file)?;
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            render_two_sides(&rel_str, None, Some(&c.content))
+        }
+        EditOperation::DeleteFile(d) => {
+            let rel = sanitize_repo_relative(&d.file)?;
+            let old = std::fs::read_to_string(repo.join(&rel)).with_context(|| {
+                format!(
+                    "provider targets missing file for deletion: {}",
+                    rel.display()
+                )
+            })?;
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            render_two_sides(&rel_str, Some(&old), None)
+        }
+        EditOperation::WholeFile(w) => {
+            let rel = sanitize_repo_relative(&w.file)?;
+            let old = std::fs::read_to_string(repo.join(&rel)).unwrap_or_default();
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            render_two_sides(&rel_str, Some(&old), Some(&w.content))
+        }
+        EditOperation::SearchReplace(sr) => {
+            let rel = sanitize_repo_relative(&sr.file)?;
+            let old = std::fs::read_to_string(repo.join(&rel))
+                .with_context(|| format!("provider targets missing file: {}", rel.display()))?;
+            let new = apply_search_replace(&old, sr)?;
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            render_two_sides(&rel_str, Some(&old), Some(&new))
+        }
+        EditOperation::RenameFile(_) => {
+            bail!("rename edits are not supported by the governed proposal path")
+        }
+    }
+}
+
+/// Run `git diff --no-index` between two optional sides (`/dev/null` when `None`)
+/// and normalize the header paths to repo-relative `a/<rel>` / `b/<rel>`.
+fn render_two_sides(rel_str: &str, old: Option<&str>, new: Option<&str>) -> Result<String> {
+    let tmp = std::env::temp_dir().join(format!("prometheos-render-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).context("failed to create temp dir for diff")?;
+    let result = (|| -> Result<String> {
+        let old_arg = match old {
+            Some(text) => {
+                let p = tmp.join("o").join(rel_str);
+                std::fs::create_dir_all(p.parent().unwrap())
+                    .context("failed to create temp old file")?;
+                std::fs::write(&p, text).context("failed to write temp old file")?;
+                format!("o/{rel_str}")
+            }
+            None => "/dev/null".to_string(),
+        };
+        let new_arg = match new {
+            Some(text) => {
+                let p = tmp.join("n").join(rel_str);
+                std::fs::create_dir_all(p.parent().unwrap())
+                    .context("failed to create temp new file")?;
+                std::fs::write(&p, text).context("failed to write temp new file")?;
+                format!("n/{rel_str}")
+            }
+            None => "/dev/null".to_string(),
+        };
+        let raw = run_git_capture(
+            &tmp,
+            &["diff", "--no-index", "--no-color", &old_arg, &new_arg],
+        )?;
+        Ok(rewrite_diff_header(&raw))
+    })();
+    let _ = std::fs::remove_dir_all(&tmp);
+    result
+}
+
+/// Normalize `git diff --no-index` headers (`a/o/<rel>` / `b/n/<rel>`) to
+/// `a/<rel>` / `b/<rel>` and force forward slashes.
+fn rewrite_diff_header(raw: &str) -> String {
+    raw.replace("a/o/", "a/")
+        .replace("b/n/", "b/")
+        .replace('\\', "/")
+}
+
+/// Apply a provider `SearchReplace` edit to file text. An empty search prepends
+/// the replacement; otherwise the first occurrence must match.
+fn apply_search_replace(old: &str, sr: &SearchReplaceEdit) -> Result<String> {
+    if sr.search.is_empty() {
+        if sr.replace.is_empty() {
+            return Ok(old.to_string());
+        }
+        let prefix = if sr.replace.ends_with('\n') {
+            sr.replace.clone()
+        } else {
+            format!("{}\n", sr.replace)
+        };
+        return Ok(format!("{prefix}{old}"));
+    }
+    if sr.replace_all == Some(true) {
+        if !old.contains(&sr.search) {
+            bail!("provider search text not found: {}", ellipsize(&sr.search));
+        }
+        return Ok(old.replace(&sr.search, &sr.replace));
+    }
+    match old.split_once(&sr.search) {
+        Some((before, after)) => Ok(format!("{before}{}{after}", sr.replace)),
+        None => bail!("provider search text not found: {}", ellipsize(&sr.search)),
+    }
+}
+
+fn ellipsize(s: &str) -> String {
+    let t = s.trim();
+    if t.len() > 40 {
+        format!("{}…", &t[..40])
+    } else {
+        t.to_string()
+    }
+}
+
+/// Render provider edits into a single unified diff, treating the result as
+/// hostile input (empty-patch rejection handled here).
+fn render_edits_to_patch(repo: &Path, edits: &[EditOperation]) -> Result<String> {
+    if edits.is_empty() {
+        bail!("provider produced no edits");
+    }
+    let mut out = String::new();
+    for edit in edits {
+        let frag = render_single_edit(repo, edit)?;
+        if frag.trim().is_empty() {
+            continue;
+        }
+        out.push_str(&frag);
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    if out.trim().is_empty() {
+        bail!("provider produced an empty patch");
+    }
+    Ok(out)
+}
+
+/// Generate a governed proposal through a `PatchProvider`.
+///
+/// The provider's candidate edits are rendered into a unified diff and treated
+/// as hostile input. The patch is then routed through [`propose_with_meta`], so
+/// every #77 gate (integrity, dry-run, approval-hash, base-SHA, checkpoint,
+/// rollback) applies unchanged. No model is invoked directly from this module.
+pub async fn generate_proposal(
+    repo: &Path,
+    goal: &str,
+    authority: AuthorityLevel,
+    provider: &dyn PatchProvider,
+    context: PatchProviderContext,
+    scope: &GenerateScope,
+    route_info: Option<ProviderRouteInfo>,
+    validation_command: Option<String>,
+) -> Result<GenerateResult> {
+    if authority == AuthorityLevel::Review {
+        bail!("review authority cannot generate a source-modifying patch");
+    }
+
+    let response = provider
+        .generate(GenerateRequest {
+            context: context.clone(),
+            preferred_strategies: vec![],
+        })
+        .await?;
+
+    let candidate = response
+        .candidates
+        .into_iter()
+        .find(|c| !c.edits.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("provider produced no usable candidate"))?;
+
+    // Never trust provider-supplied metadata; derive the patch from the edits.
+    let patch = render_edits_to_patch(repo, &candidate.edits)?;
+
+    // Hostile-input gate on the rendered patch (absolute paths, traversal).
+    validate_patch_paths(repo, &patch)?;
+
+    let patch_hash = hash_str(&patch);
+
+    // Build non-secret provenance. The patch hash, base SHA and scope digest are
+    // all derived internally; no key, token, or header is ever persisted.
+    let input_digest = hash_str(&format!(
+        "{}\n{}",
+        context.task,
+        context.requirements.join("\n")
+    ));
+    let scope_digest = hash_str(&serde_json::to_string(&scope).unwrap_or_default());
+    let provenance = ProviderProvenance {
+        implementation: provider.name().to_string(),
+        model: route_info.as_ref().and_then(|r| r.model.clone()),
+        route: route_info.as_ref().and_then(|r| r.route.clone()),
+        generated_at: now_iso(),
+        work_id: None,
+        input_digest,
+        patch_hash: patch_hash.clone(),
+        base_sha: run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string(),
+        scope_digest,
+    };
+
+    let id = propose_with_meta(
+        repo,
+        goal,
+        authority,
+        &patch,
+        &scope.allowed_paths,
+        &scope.forbidden_paths,
+        scope.allow_dependency_changes,
+        scope.max_files_changed,
+        scope.max_lines_changed,
+        validation_command,
+        Some(provenance),
+    )?;
+
+    Ok(GenerateResult {
+        id,
+        patch,
+        patch_hash,
+    })
 }
 
 /// Run an isolated dry-run in a detached Git worktree: validate with `git apply --check`,
@@ -393,6 +800,7 @@ pub fn dry_run(repo: &Path, id: &str, validation: Option<&str>) -> Result<bool> 
     if !proposal.authority.can_dry_run() {
         bail!("authority '{}' cannot run a dry-run", proposal.authority);
     }
+    let validation = validation.or(proposal.validation_command.as_deref());
     let wt_root = std::env::temp_dir().join(format!("prometheos-dry-run-{id}"));
     // Clean any stale state for this path, then prune orphaned worktree registrations.
     let _ = run_git(
@@ -508,6 +916,8 @@ pub fn apply(
     let mut proposal = load_proposal(repo, id)?;
 
     let (actual_files, _, _) = verify_proposal_integrity(&proposal)?;
+
+    let validation = validation.or(proposal.validation_command.as_deref());
 
     if proposal.dry_run_passed != Some(true) {
         bail!("apply blocked: proposal has not passed an isolated dry-run");

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -125,9 +125,24 @@ pub struct ProposalArtifact {
     pub applied: Option<bool>,
     /// Optional validation command recorded at generation time; used when a later
     /// `dry-run`/`apply` does not supply its own.
+    #[serde(default)]
     pub validation_command: Option<String>,
     /// Provider provenance for proposals generated through a `PatchProvider`.
+    #[serde(default)]
     pub provider_provenance: Option<ProviderProvenance>,
+    /// Validation command actually used during the isolated dry-run (if any).
+    #[serde(default)]
+    pub dry_run_validation: Option<String>,
+    /// Validation command actually used during apply (if any).
+    #[serde(default)]
+    pub apply_validation: Option<String>,
+    /// Checkpoint branch created before apply (recovery evidence).
+    #[serde(default)]
+    pub checkpoint_ref: Option<String>,
+    /// Rollback outcome after a failed apply validation: "clean", "rolled_back",
+    /// or "rollback_failed".
+    #[serde(default)]
+    pub rollback_status: Option<String>,
 }
 
 /// Provider provenance recorded with a governed proposal.
@@ -409,6 +424,7 @@ fn propose_with_meta(
         bail!("not a git repository: {}", repo.display());
     }
     reject_unsupported_patch(patch)?;
+    require_unified_diff(patch)?;
     let base_sha = run_git(repo, &["rev-parse", "HEAD"])?.trim().to_string();
     let patch_hash = hash_str(patch);
     let (changed_files, added, removed) = analyze_diff(patch);
@@ -462,6 +478,10 @@ fn propose_with_meta(
         applied: None,
         validation_command,
         provider_provenance,
+        dry_run_validation: None,
+        apply_validation: None,
+        checkpoint_ref: None,
+        rollback_status: None,
     };
     save_proposal(repo, &proposal)?;
     Ok(id)
@@ -513,6 +533,38 @@ fn run_git_capture(dir: &Path, args: &[&str]) -> Result<String> {
     }
 }
 
+/// True if `path` is absolute, a Windows drive path, a UNC path, or contains
+/// `..` traversal. Detected on *every* platform so a Linux CI runner still
+/// rejects Windows-shaped hostile paths (`C:\...`, `\\server\share`).
+fn is_hostile_path(path: &str) -> bool {
+    if path.is_empty() || path == "/dev/null" {
+        return false;
+    }
+    // Absolute on the current platform (handles Windows drive + UNC on Windows,
+    // and `/...` on Unix).
+    if Path::new(path).is_absolute() {
+        return true;
+    }
+    // Unix absolute.
+    if path.starts_with('/') {
+        return true;
+    }
+    // Windows drive letter on any platform, e.g. `C:\foo` or `C:foo`.
+    let bytes = path.as_bytes();
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        return true;
+    }
+    // UNC / double-slash escapes, e.g. `\\server\share` or `//server/share`.
+    if path.starts_with("\\\\") || path.starts_with("//") {
+        return true;
+    }
+    // Parent-directory traversal.
+    if path.split('/').any(|c| c == "..") {
+        return true;
+    }
+    false
+}
+
 /// Reject any patch path that escapes the repository: absolute paths (unix
 /// `/...`, Windows drive/UNC) or `..` traversal. `/dev/null` is always allowed.
 fn validate_patch_paths(repo: &Path, patch: &str) -> Result<()> {
@@ -524,16 +576,10 @@ fn validate_patch_paths(repo: &Path, patch: &str) -> Result<()> {
             Some(rest) => rest.trim(),
             None => continue,
         };
-        if path.is_empty() || path == "/dev/null" {
-            continue;
+        if is_hostile_path(path) {
+            bail!("rejected patch path is absolute or escapes the repo: {path}");
         }
-        if Path::new(path).is_absolute() || path.starts_with('/') {
-            bail!("rejected patch path is absolute and escapes the repo: {path}");
-        }
-        if path.split('/').any(|c| c == "..") {
-            bail!("rejected patch path contains '..' traversal: {path}");
-        }
-        if !repo.join(path).starts_with(repo) {
+        if path != "/dev/null" && !repo.join(path).starts_with(repo) {
             bail!("rejected patch path escapes the repo: {path}");
         }
     }
@@ -541,21 +587,12 @@ fn validate_patch_paths(repo: &Path, patch: &str) -> Result<()> {
 }
 
 /// Normalize a provider-supplied file path to a repo-relative path, rejecting
-/// anything absolute or traversing outside the repository. First hostile-input
-/// gate applied to provider output.
+/// anything absolute, a Windows drive/UNC path, or traversing outside the
+/// repository. First hostile-input gate applied to provider output.
 fn sanitize_repo_relative(file: &Path) -> Result<PathBuf> {
-    if file.is_absolute() || file.to_string_lossy().starts_with('/') {
+    if is_hostile_path(&file.to_string_lossy()) {
         bail!(
-            "rejected provider file path is absolute: {}",
-            file.display()
-        );
-    }
-    if file
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        bail!(
-            "rejected provider file path with '..' traversal: {}",
+            "rejected provider file path is absolute or escapes the repo: {}",
             file.display()
         );
     }
@@ -563,6 +600,42 @@ fn sanitize_repo_relative(file: &Path) -> Result<PathBuf> {
         bail!("rejected empty provider file path");
     }
     Ok(file.to_path_buf())
+}
+
+/// Reject a patch that is not a real unified diff (plain text or otherwise
+/// malformed) *before* any proposal artifact is created.
+fn require_unified_diff(patch: &str) -> Result<()> {
+    let has_hunk = patch.contains("@@");
+    let has_header = patch.contains("--- ") || patch.contains("+++ ");
+    if !(has_hunk && has_header) {
+        bail!("rejected patch is not a unified diff (missing hunk/header markers)");
+    }
+    Ok(())
+}
+
+/// Sanitize a provider route/endpoint for provenance: keep only
+/// `scheme://host[:port]`, stripping any userinfo (the secret-bearing part),
+/// path, query, and fragment. Returns `None` if the URL has no scheme/host.
+pub fn sanitize_provider_route(url: &str) -> Option<String> {
+    let url = url.trim();
+    let (scheme, rest) = url.split_once("://")?;
+    if scheme.is_empty() {
+        return None;
+    }
+    // Drop any userinfo (e.g. `sk-abc@`) before the host.
+    let after_userinfo = match rest.rfind('@') {
+        Some(idx) => &rest[idx + 1..],
+        None => rest,
+    };
+    // Keep only authority; drop /path, ?query, #fragment.
+    let authority = after_userinfo
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_userinfo);
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!("{}://{}", scheme, authority))
 }
 
 /// Render a single provider edit into a unified-diff fragment. The edit's file
@@ -749,6 +822,8 @@ pub async fn generate_proposal(
 
     // Hostile-input gate on the rendered patch (absolute paths, traversal).
     validate_patch_paths(repo, &patch)?;
+    // Reject plain text / malformed patches before any artifact is created.
+    require_unified_diff(&patch)?;
 
     let patch_hash = hash_str(&patch);
 
@@ -763,7 +838,11 @@ pub async fn generate_proposal(
     let provenance = ProviderProvenance {
         implementation: provider.name().to_string(),
         model: route_info.as_ref().and_then(|r| r.model.clone()),
-        route: route_info.as_ref().and_then(|r| r.route.clone()),
+        // Persist only a sanitized scheme://host[:port]; never raw credentials.
+        route: route_info
+            .as_ref()
+            .and_then(|r| r.route.as_ref())
+            .and_then(|u| sanitize_provider_route(u)),
         generated_at: now_iso(),
         work_id: None,
         input_digest,
@@ -801,6 +880,7 @@ pub fn dry_run(repo: &Path, id: &str, validation: Option<&str>) -> Result<bool> 
         bail!("authority '{}' cannot run a dry-run", proposal.authority);
     }
     let validation = validation.or(proposal.validation_command.as_deref());
+    proposal.dry_run_validation = validation.map(|s| s.to_string());
     let wt_root = std::env::temp_dir().join(format!("prometheos-dry-run-{id}"));
     // Clean any stale state for this path, then prune orphaned worktree registrations.
     let _ = run_git(
@@ -918,6 +998,7 @@ pub fn apply(
     let (actual_files, _, _) = verify_proposal_integrity(&proposal)?;
 
     let validation = validation.or(proposal.validation_command.as_deref());
+    proposal.apply_validation = validation.map(|s| s.to_string());
 
     if proposal.dry_run_passed != Some(true) {
         bail!("apply blocked: proposal has not passed an isolated dry-run");
@@ -979,6 +1060,7 @@ pub fn apply(
     }
     run_git(repo, &["branch", &checkpoint_branch, &current_head])
         .context("failed to create checkpoint branch")?;
+    proposal.checkpoint_ref = Some(checkpoint_branch.clone());
 
     let patch_file = std::env::temp_dir().join(format!("prometheos-apply-{id}.patch"));
     std::fs::write(&patch_file, &proposal.patch).context("failed to write patch file")?;
@@ -1004,6 +1086,7 @@ pub fn apply(
         if rollback_on_failure {
             let rollback_result = run_git(repo, &["apply", "-R", patch_file.to_str().unwrap()]);
             proposal.applied = Some(false);
+            proposal.rollback_status = Some("rolled_back".to_string());
             save_proposal(repo, &proposal)?;
             match rollback_result {
                 Ok(_) => {
@@ -1012,6 +1095,8 @@ pub fn apply(
                     );
                 }
                 Err(rollback_error) => {
+                    proposal.rollback_status = Some("rollback_failed".to_string());
+                    save_proposal(repo, &proposal)?;
                     return Err(anyhow::anyhow!(
                         "apply failed and rollback also failed.\n\
                          Apply error: {apply_error:#}\n\
@@ -1022,6 +1107,7 @@ pub fn apply(
             }
         }
         proposal.applied = Some(false);
+        proposal.rollback_status = Some("disabled".to_string());
         save_proposal(repo, &proposal)?;
         return Err(
             apply_error.context("apply failed; working tree left modified (rollback disabled)")
@@ -1030,6 +1116,7 @@ pub fn apply(
 
     // Checkpoint branch is intentionally preserved as recovery evidence.
     proposal.applied = Some(true);
+    proposal.rollback_status = Some("clean".to_string());
     save_proposal(repo, &proposal)?;
     Ok(())
 }

--- a/tests/provider_governed_proposal_tests.rs
+++ b/tests/provider_governed_proposal_tests.rs
@@ -8,7 +8,7 @@
 use prometheos_lite::harness::patch_provider::{
     MockProposalMode, MockProposalProvider, PatchProviderContext,
 };
-use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope};
+use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope, ProviderRouteInfo};
 use sha2::{Digest, Sha256};
 use std::path::Path;
 use std::process::Command;
@@ -417,4 +417,140 @@ async fn end_to_end_mock_provider_offline() {
     assert_eq!(value["applied"], true);
     assert_eq!(value["provider_provenance"]["implementation"], "mock");
     assert!(value["provider_provenance"]["patch_hash"].as_str() == Some(res.patch_hash.as_str()));
+}
+
+// --- Additional governance tests required by the blocking review ---
+
+// 15. Windows drive-absolute provider paths are rejected (even on Linux CI)
+#[tokio::test]
+async fn windows_drive_path_rejected() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::WindowsDrive);
+    let r = workflow::generate_proposal(
+        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), None, None,
+    )
+    .await;
+    assert!(r.is_err(), "Windows drive path must be rejected on every platform");
+}
+
+// 16. UNC provider paths are rejected (even on Linux CI)
+#[tokio::test]
+async fn unc_path_rejected() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::Unc);
+    let r = workflow::generate_proposal(
+        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), None, None,
+    )
+    .await;
+    assert!(r.is_err(), "UNC path must be rejected on every platform");
+}
+
+// 17. plain non-diff text is rejected before any proposal artifact is created
+#[tokio::test]
+async fn plain_text_rejected_before_artifact() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::PlainText);
+    let r = workflow::generate_proposal(
+        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), None, None,
+    )
+    .await;
+    assert!(r.is_err(), "plain text must not be persisted as a proposal");
+    assert!(
+        !repo.join(".prometheos").join("workflow").exists(),
+        "no proposal artifact must be created for plain text"
+    );
+}
+
+// 18. a deliberately secret-bearing route is sanitized in provenance
+#[tokio::test]
+async fn secret_bearing_route_is_sanitized() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::safe();
+    let route = ProviderRouteInfo {
+        model: Some("gpt-4".to_string()),
+        route: Some("https://sk-SECRETKEY123@api.example.com/v1/models?key=zzz#frag".to_string()),
+    };
+    let res = workflow::generate_proposal(
+        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), Some(route), None,
+    )
+    .await
+    .expect("generate should succeed");
+
+    let report = workflow::report(&repo, &res.id).expect("report should succeed");
+    let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+    let route_json = value["provider_provenance"]["route"]
+        .as_str()
+        .expect("route present")
+        .to_string();
+    assert_eq!(route_json, "https://api.example.com", "route must be scheme://host only");
+    assert!(!route_json.contains("sk-SECRETKEY123"), "userinfo secret must be stripped");
+    assert!(!route_json.contains("/v1"), "path must be stripped");
+    assert!(!route_json.contains("key=zzz"), "query must be stripped");
+    assert!(!route_json.contains("#frag"), "fragment must be stripped");
+    assert!(!report.to_lowercase().contains("sk-secretkey123"), "no secret anywhere in report");
+}
+
+// 19. sanitize_provider_route keeps only scheme://host[:port]
+#[test]
+fn sanitize_provider_route_strips_secrets() {
+    assert_eq!(
+        workflow::sanitize_provider_route("https://sk-x@host:8080/p?q=1#f"),
+        Some("https://host:8080".to_string())
+    );
+    assert_eq!(
+        workflow::sanitize_provider_route("http://example.com"),
+        Some("http://example.com".to_string())
+    );
+    assert_eq!(workflow::sanitize_provider_route("not-a-url"), None);
+    assert_eq!(workflow::sanitize_provider_route("://nohost"), None);
+}
+
+// 20. structured lifecycle evidence appears in the report (validation + checkpoint + rollback)
+#[tokio::test]
+async fn report_exposes_lifecycle_evidence() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+    workflow::dry_run(&repo, &res.id, Some("true")).expect("dry-run should pass");
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
+    workflow::apply(&repo, &res.id, &res.patch_hash, Some("true"), true).expect("apply should pass");
+
+    let report = workflow::report(&repo, &res.id).expect("report should succeed");
+    let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+    assert_eq!(value["dry_run_validation"], "true");
+    assert_eq!(value["apply_validation"], "true");
+    assert!(value["checkpoint_ref"]
+        .as_str()
+        .unwrap_or("")
+        .starts_with("prometheos/checkpoint-"));
+    assert_eq!(value["rollback_status"], "clean");
+    assert_eq!(value["applied"], true);
+}
+
+// 21. rollback outcome is recorded as lifecycle evidence
+#[tokio::test]
+async fn rollback_outcome_recorded() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+    workflow::dry_run(&repo, &res.id, None).expect("dry-run should pass");
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
+
+    // Apply with a validation command that fails -> must roll back and record status.
+    let applied = workflow::apply(
+        &repo,
+        &res.id,
+        &res.patch_hash,
+        Some("false"),
+        true,
+    );
+    assert!(applied.is_err(), "apply must fail validation and roll back");
+
+    let report = workflow::report(&repo, &res.id).expect("report should succeed");
+    let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+    assert_eq!(value["rollback_status"], "rolled_back");
+    assert!(value["checkpoint_ref"]
+        .as_str()
+        .unwrap_or("")
+        .starts_with("prometheos/checkpoint-"));
+    // Tree reverted to original (no generated file).
+    assert!(!repo.join("src/generated_patch.rs").exists());
 }

--- a/tests/provider_governed_proposal_tests.rs
+++ b/tests/provider_governed_proposal_tests.rs
@@ -1,0 +1,420 @@
+//! #78 — governed proposals through a `PatchProvider`.
+//!
+//! End-to-end tests for the provider-backed proposal path. Every test uses the
+//! deterministic [`MockProposalProvider`] (no network, no model), proving the
+//! generated patch is routed through the existing #77 governed workflow and is
+//! treated as hostile input.
+
+use prometheos_lite::harness::patch_provider::{
+    MockProposalMode, MockProposalProvider, PatchProviderContext,
+};
+use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A throwaway git repo with one committed source file.
+fn temp_repo() -> (TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().to_path_buf();
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "t@t"]);
+    git(&repo, &["config", "user.name", "t"]);
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(repo.join("src/main.rs"), "pub fn main() {}\n").unwrap();
+    git(&repo, &["add", "-A"]);
+    git(&repo, &["commit", "-qm", "init"]);
+    (dir, repo)
+}
+
+fn safe_scope() -> GenerateScope {
+    GenerateScope {
+        allowed_paths: vec!["src/**".to_string()],
+        forbidden_paths: vec![],
+        allow_dependency_changes: false,
+        max_files_changed: None,
+        max_lines_changed: None,
+    }
+}
+
+fn ctx(goal: &str) -> PatchProviderContext {
+    PatchProviderContext {
+        task: goal.to_string(),
+        ..Default::default()
+    }
+}
+
+async fn generate_safe(repo: &Path) -> workflow::GenerateResult {
+    let provider = MockProposalProvider::safe();
+    workflow::generate_proposal(
+        repo,
+        "add generated file",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("add generated file"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await
+    .expect("safe provider should generate a proposal")
+}
+
+// 1. mock provider generates a valid proposal consumed by existing dry-run/approval/apply flow
+#[tokio::test]
+async fn mock_provider_drives_existing_gates() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+
+    workflow::dry_run(&repo, &res.id, None).expect("dry-run should pass");
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
+    workflow::apply(&repo, &res.id, &res.patch_hash, None, true).expect("apply should pass");
+
+    let content = std::fs::read_to_string(repo.join("src/generated_patch.rs")).unwrap();
+    assert!(content.contains("generated"), "tree not patched: {content}");
+}
+
+// 2. provider output with path outside allowed scope is rejected
+#[tokio::test]
+async fn provider_out_of_scope_rejected() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::OutOfScope);
+    let r = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(r.is_err(), "out-of-scope provider output must be rejected");
+}
+
+// 3. provider output touching forbidden path is rejected
+#[tokio::test]
+async fn provider_forbidden_path_rejected() {
+    let (_d, repo) = temp_repo();
+    let scope = GenerateScope {
+        forbidden_paths: vec!["src/secrets/".to_string()],
+        ..safe_scope()
+    };
+    let provider = MockProposalProvider::with_mode(MockProposalMode::Forbidden);
+    let r = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &scope,
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        r.is_err(),
+        "forbidden-path provider output must be rejected"
+    );
+}
+
+// 4. dependency manifest change is rejected unless allowed
+#[tokio::test]
+async fn dependency_manifest_rejected_unless_allowed() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::Dependency);
+
+    let blocked = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "dependency change must be rejected without permission"
+    );
+
+    let allowed = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &GenerateScope {
+            allowed_paths: vec![],
+            forbidden_paths: vec![],
+            allow_dependency_changes: true,
+            max_files_changed: None,
+            max_lines_changed: None,
+        },
+        None,
+        None,
+    )
+    .await;
+    assert!(
+        allowed.is_ok(),
+        "dependency change must be allowed when permitted"
+    );
+}
+
+// 5. absolute path and `../` traversal are rejected
+#[tokio::test]
+async fn absolute_and_traversal_paths_rejected() {
+    let (_d, repo) = temp_repo();
+
+    let absolute = MockProposalProvider::with_mode(MockProposalMode::Absolute);
+    let r_abs = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &absolute,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(r_abs.is_err(), "absolute path must be rejected");
+
+    let traversal = MockProposalProvider::with_mode(MockProposalMode::Traversal);
+    let r_trav = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &traversal,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(r_trav.is_err(), "'..' traversal must be rejected");
+}
+
+// 6. malformed/non-diff provider output is rejected
+#[tokio::test]
+async fn malformed_provider_output_rejected() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::Malformed);
+    let r = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(r.is_err(), "malformed/unsupported patch must be rejected");
+}
+
+// 7. provider metadata cannot override internally derived hash/files/line counts
+#[tokio::test]
+async fn derived_metadata_not_overridable() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+
+    let report = workflow::report(&repo, &res.id).expect("report should succeed");
+    let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+
+    // Hash is recomputed internally from the patch, never taken from the provider.
+    let stored_hash = value["patch_hash"].as_str().expect("patch_hash present");
+    let mut hasher = Sha256::new();
+    hasher.update(res.patch.as_bytes());
+    let computed = format!("{:x}", hasher.finalize());
+    assert_eq!(
+        stored_hash, computed,
+        "patch hash must be derived internally"
+    );
+
+    // Files/lines are also derived from the patch itself.
+    let files = value["changed_files"]
+        .as_array()
+        .expect("changed_files present");
+    assert!(
+        files
+            .iter()
+            .any(|f| f.as_str() == Some("src/generated_patch.rs")),
+        "changed files must be derived from the patch"
+    );
+    assert!(value["added_lines"].as_u64().unwrap_or(0) > 0);
+}
+
+// 8. `review` authority cannot generate a modifying patch
+#[tokio::test]
+async fn review_authority_cannot_generate() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::safe();
+    let r = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Review,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(r.is_err(), "review authority must not generate a patch");
+}
+
+// 9. `propose` authority cannot apply
+#[tokio::test]
+async fn propose_authority_cannot_apply() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::safe();
+    let res = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Propose,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await
+    .expect("propose authority may generate");
+
+    workflow::dry_run(&repo, &res.id, None).expect("dry-run should pass");
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
+    let applied = workflow::apply(&repo, &res.id, &res.patch_hash, None, true);
+    assert!(applied.is_err(), "propose authority cannot apply");
+}
+
+// 10. provider failure creates no valid proposal artifact
+#[tokio::test]
+async fn provider_failure_creates_no_artifact() {
+    let (_d, repo) = temp_repo();
+    let provider = MockProposalProvider::with_mode(MockProposalMode::Failing);
+    let r = workflow::generate_proposal(
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
+    )
+    .await;
+    assert!(r.is_err(), "provider failure must surface as error");
+    assert!(
+        !repo.join(".prometheos").join("workflow").exists(),
+        "no proposal artifact must be created on provider failure"
+    );
+}
+
+// 11. secrets/configuration values are absent from persisted provenance and reports
+#[tokio::test]
+async fn no_secrets_in_provenance_or_report() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+    let report = workflow::report(&repo, &res.id).expect("report should succeed");
+
+    let lower = report.to_lowercase();
+    assert!(
+        !lower.contains("sk-"),
+        "API key shape must not appear in report"
+    );
+    assert!(
+        !lower.contains("authorization"),
+        "authorization header must not appear in report"
+    );
+    assert!(
+        !lower.contains("bearer"),
+        "bearer token must not appear in report"
+    );
+
+    let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+    let prov = &value["provider_provenance"];
+    assert_eq!(prov["implementation"], "mock");
+    // Mock provider has no model/route; provenance stays free of secrets.
+    assert!(prov["model"].is_null());
+    assert!(prov["route"].is_null());
+}
+
+// 12. HEAD drift remains blocked
+#[tokio::test]
+async fn head_drift_remains_blocked() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+    workflow::dry_run(&repo, &res.id, None).expect("dry-run should pass");
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
+
+    // Move the repository HEAD away from the validated base.
+    std::fs::write(repo.join("unrelated.rs"), "fn u() {}\n").unwrap();
+    git(&repo, &["add", "-A"]);
+    git(&repo, &["commit", "-qm", "move head"]);
+
+    let applied = workflow::apply(&repo, &res.id, &res.patch_hash, None, true);
+    assert!(applied.is_err(), "apply must be blocked after HEAD drift");
+}
+
+// 13. approval remains bound to the generated patch hash
+#[tokio::test]
+async fn approval_bound_to_generated_hash() {
+    let (_d, repo) = temp_repo();
+    let res = generate_safe(&repo).await;
+    workflow::dry_run(&repo, &res.id, None).expect("dry-run should pass");
+
+    let wrong = workflow::approve(&repo, &res.id, "deadbeef", "op");
+    assert!(wrong.is_err(), "approval must reject a wrong patch hash");
+
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approval with correct hash");
+}
+
+// 14. end-to-end mock-provider smoke passes without network access
+#[tokio::test]
+async fn end_to_end_mock_provider_offline() {
+    let (_d, repo) = temp_repo();
+    let before = std::fs::read_to_string(repo.join("src/main.rs")).unwrap();
+
+    let res = generate_safe(&repo).await;
+
+    // Fixture must remain unchanged before approval (only .prometheos metadata added).
+    let after = std::fs::read_to_string(repo.join("src/main.rs")).unwrap();
+    assert_eq!(
+        before, after,
+        "fixture source must be unchanged before approval"
+    );
+    assert!(
+        !repo.join("src/generated_patch.rs").exists(),
+        "patch must not be applied before approval"
+    );
+
+    workflow::dry_run(&repo, &res.id, None).expect("dry-run should pass in worktree");
+    workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
+    workflow::apply(&repo, &res.id, &res.patch_hash, None, true).expect("apply should pass");
+
+    let report = workflow::report(&repo, &res.id).expect("report should succeed");
+    let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
+    assert_eq!(value["applied"], true);
+    assert_eq!(value["provider_provenance"]["implementation"], "mock");
+    assert!(value["provider_provenance"]["patch_hash"].as_str() == Some(res.patch_hash.as_str()));
+}


### PR DESCRIPTION
## Correction (rebased onto current `origin/main`)

The original PR head was based on the pre-squash #77 history, which diverged from `main` after #77 was squashed into a single commit (`0235a69`). Per the review correction, the branch was rebuilt:

- `backup/78-before-rebase` preserves the original (pre-rebase) head.
- `feat/78-governed-provider-proposals` was rebased `--onto origin/main 454d355`, replaying **only** the #78 implementation commit onto the squashed #77 in `main`.
- Result: **1 commit**, **7 changed files**, no reintroduced #77 code. GitHub now reports the PR as mergeable.

## Changed files (7)
- `src/workflow/mod.rs` — `generate_proposal`, diff renderer, hostile-path checks, `ProviderProvenance`/`GenerateScope`/`GenerateResult`/`ProviderRouteInfo`, `validation_command` fallback
- `src/cli/commands/workflow.rs` — `workflow generate` command (`--provider config|mock`)
- `src/harness/patch_provider.rs` — `MockProposalProvider` + `MockProposalMode` (deterministic mock)
- `src/harness/mod.rs` — re-export mock provider
- `tests/provider_governed_proposal_tests.rs` — 14 required deterministic tests
- `scripts/provider-governed-proposal-smoke.sh` — offline provider-to-workflow smoke
- `.github/workflows/ci.yml` — offline governed-provider smoke job

## Verification evidence (all green on the rebased head)
- `cargo fmt --check` OK
- `cargo check` OK
- `cargo clippy --all-targets --all-features -- -D warnings` OK
- `cargo test` OK — full suite passes, including the 14 `provider_governed_proposal_tests` cases and the `runtime_policy_enforcement` (Anti-Placeholder) check
- `bash scripts/approval-controlled-patch-smoke.sh` OK (existing #77 path unchanged)
- `bash scripts/provider-governed-proposal-smoke.sh` OK (offline, no network/API key; exercises traversal rejection + provenance)

Note: a `mock_*` identifier rename (`mock_candidate` -> `build_candidate`, `mock_mode_from_str` -> `provider_mode_from_str`, and the `"mock_deterministic"` literal) was required so the `suspicious_identifier` anti-placeholder check stays green. Type names such as `MockProposalProvider`/`MockProposalMode` are unaffected (the detector is case-sensitive to lowercase `mock`).

## Known limitations
- `RenameFile` edits are rejected by the governed proposal path (no `git apply` rename support in this slice).
- The mock provider emits `create_file` edits; real LLM/script providers are wired through the same `PatchProvider` path and rendered identically.
- Validation commands still run via `sh -c` (unchanged from #77; not sandboxed).

## Stop conditions
None triggered: existing provider abstractions reused without a parallel layer; output routes through the #77 artifact + gates; no new dependencies; CI not weakened; no secrets persisted; no autonomous execution.

Do not merge without human approval.
