### PR TITLE
docs: governed bug-fix tutorial + Governed Patch Pilot plan

### DIFF
--- a/docs/guides/safely-fix-a-real-bug.md
+++ b/docs/guides/safely-fix-a-real-bug.md
@@ -1,0 +1,167 @@
+# Safely fix a real bug with PrometheOS Lite
+
+This tutorial walks through the governed patch workflow: a model/provider
+generates edits, but **every change passes through dry-run, human approval, a
+checkpoint, application, validation, and a recoverable evidence report** before
+it touches your tree permanently.
+
+PrometheOS does not trust provider output. A generated patch is treated as
+hostile input: absolute paths, `..` traversal, Windows drive/UNC paths, plain
+non-diff text, and out-of-scope files are all rejected. Provenance is recorded
+without secrets.
+
+## 1. Install
+
+```bash
+git clone https://github.com/prometheosai/prometheos-lite.git
+cd prometheos-lite
+cargo install --path .
+prometheos --version
+```
+
+## 2. Configure a provider
+
+The `workflow generate --provider config` path reads a small config file from
+the current directory and optional environment overrides:
+
+`prometheos.config.json`:
+
+```json
+{
+  "provider": "openai",
+  "model": "your-model-name",
+  "base_url": "https://openrouter.ai/api"
+}
+```
+
+Environment overrides (optional):
+
+```bash
+export PROMETHEOS_BASE_URL="https://openrouter.ai/api"
+export PROMETHEOS_MODEL="your-model-name"
+```
+
+If your provider needs an API key, supply it per the provider's own
+documentation. PrometheOS records only a sanitized `scheme://host[:port]` in
+provenance and never persists keys, tokens, or authorization headers.
+
+For an offline, no-model run, use `--provider mock` instead of `--provider config`.
+
+## 3. Choose a repository
+
+Pick a real repository you want changed. PrometheOS operates on a Git checkout
+and creates a checkpoint branch before applying anything, so the working tree
+must be a Git repository.
+
+```bash
+cd /path/to/your-repo
+git status   # clean tree recommended
+```
+
+## 4. Set scope
+
+Limit blast radius with `--allowed`, `--forbidden`, `--max-files`, and
+`--max-lines`. Anything outside the allowed globs is rejected before any
+artifact is created.
+
+```bash
+prometheos workflow generate \
+  --repo /path/to/your-repo \
+  --goal "Fix the off-by-one in the parser boundary check" \
+  --authority assist \
+  --allowed "src/**" \
+  --forbidden "src/vendor/**" \
+  --max-files 3 \
+  --max-lines 120 \
+  --validate "cargo test" \
+  --provider config
+```
+
+This prints a `<WORKFLOW_ID>` and a `patch_hash`. Keep both.
+
+## 5. Generate the proposal
+
+The command above already generated the proposal. If you prefer to generate
+separately from inspecting, re-run `generate` any time; each run produces a new
+governed proposal artifact.
+
+## 6. Inspect the report
+
+Before approving anything, read the evidence report:
+
+```bash
+prometheos workflow report --repo /path/to/your-repo <WORKFLOW_ID>
+```
+
+Confirm:
+
+- `provider_provenance.implementation`, `.model`, and `.route` are correct and
+  contain no secrets.
+- No API keys, tokens, or `Authorization` headers appear anywhere in the output.
+- `changed_files` match the goal and stay inside your `--allowed` scope.
+- `validation_command` is recorded (e.g. `cargo test`).
+- `patch` and `patch_hash` are present and exact.
+- `approved`, `dry_run_passed`, and `applied` are all `null` — your source
+  files are **unchanged** until you approve and apply.
+
+## 7. Dry-run
+
+The proposal is applied to an isolated Git worktree and your validation command
+runs there. Your real tree is untouched.
+
+```bash
+prometheos workflow dry-run --repo /path/to/your-repo <WORKFLOW_ID>
+```
+
+A failed dry-run (including a failing validation command) records the failure
+and blocks apply. No changes reach your tree.
+
+## 8. Approve
+
+Approval is bound to the exact `patch_hash`. A different hash is rejected.
+
+```bash
+prometheos workflow approve \
+  --repo /path/to/your-repo \
+  <WORKFLOW_ID> \
+  --patch-hash <PATCH_HASH> \
+  --approver <your-name>
+```
+
+## 9. Apply
+
+Apply creates a checkpoint branch (`prometheos/checkpoint-<WORKFLOW_ID>`),
+re-checks scope, runs validation again, and only then applies the patch.
+
+```bash
+prometheos workflow apply \
+  --repo /path/to/your-repo \
+  <WORKFLOW_ID> \
+  --patch-hash <PATCH_HASH>
+```
+
+If validation fails after apply, PrometheOS attempts an automatic rollback and
+records `rollback_status` (`clean`, `rolled_back`, or `rollback_failed`) in the
+report.
+
+## 10. Rollback / recovery
+
+Recovery is built into the artifact:
+
+- The checkpoint branch preserves the pre-apply state.
+- `report` always shows `checkpoint_ref` and `rollback_status`.
+- If apply left the tree modified and rollback was disabled, use the checkpoint:
+
+```bash
+git checkout <checkpoint_ref> -- .     # restore files from checkpoint
+# or restore the whole branch state from the checkpoint ref
+```
+
+## Security warning
+
+The validation command you pass to `--validate` (and to `dry-run`/`apply`) is
+executed with **your operating system permissions and is not sandboxed**. A
+malicious or careless validation string can read, write, or execute anything
+your user account can. Do not pass untrusted validation commands. The `sh -c`
+invocation used for validation is intentionally unsandboxed; treat it like a
+command you typed into your own shell.

--- a/docs/guides/safely-fix-a-real-bug.md
+++ b/docs/guides/safely-fix-a-real-bug.md
@@ -30,14 +30,14 @@ the current directory and optional environment overrides:
 {
   "provider": "openai",
   "model": "your-model-name",
-  "base_url": "https://openrouter.ai/api"
+  "base_url": "https://openrouter.ai/api/v1"
 }
 ```
 
 Environment overrides (optional):
 
 ```bash
-export PROMETHEOS_BASE_URL="https://openrouter.ai/api"
+export PROMETHEOS_BASE_URL="https://openrouter.ai/api/v1"
 export PROMETHEOS_MODEL="your-model-name"
 ```
 

--- a/docs/research/governed-patch-pilot.md
+++ b/docs/research/governed-patch-pilot.md
@@ -1,0 +1,142 @@
+# Milestone: Governed Patch Pilot
+
+**Status:** planned — blocked on a live configured provider in this environment.
+
+**Purpose:** Stop building platform foundations and prove PrometheOS Lite on
+real repositories. The product already has the full governed path:
+
+```
+goal
+  -> provider generates edits
+  -> governed proposal (hostile-input + scope checks)
+  -> isolated dry-run
+  -> human approval (bound to exact patch hash)
+  -> checkpoint
+  -> application
+  -> validation + rollback
+  -> evidence report
+```
+
+The claim to validate is **not** "PrometheOS writes better code than every
+model." It is: *PrometheOS makes model-generated software changes safer,
+reviewable, reproducible, and recoverable.*
+
+## Tasks
+
+Run **10 real tasks across at least 5 repositories**, in three categories:
+
+1. A repository you know well.
+2. A repository you barely know.
+3. A public repository maintained by someone else.
+
+Tasks are small but real (no synthetic "create generated_patch.rs" demos):
+
+- fix a failing unit test
+- add input validation
+- repair an error message
+- update a deprecated API
+- add one missing test
+- fix a boundary condition
+- correct a configuration bug
+- remove a small duplication
+- add a narrowly scoped CLI option
+- repair a documentation/code mismatch
+
+## Metrics (one structured result file per run)
+
+```json
+{
+  "repository": "owner/repo",
+  "task": "Fix boundary condition in parser",
+  "provider": "openrouter",
+  "model": "model-name",
+  "authority": "assist",
+  "proposal_generated": true,
+  "dry_run_passed": true,
+  "approved": true,
+  "applied": true,
+  "validation_passed": true,
+  "rollback_used": false,
+  "files_changed": 2,
+  "lines_changed": 31,
+  "scope_violations": 0,
+  "human_edits_required": 1,
+  "time_to_first_proposal_seconds": 48,
+  "total_time_seconds": 310,
+  "provider_cost_usd": 0.07,
+  "useful": true,
+  "notes": "Changed one extra test fixture before scope was tightened"
+}
+```
+
+Key measurements: task correctness, scope adherence, human correction
+required, regression rate, approval rejection rate, dry-run failure rate, time
+saved, provider cost, rollback success, and whether the evidence report
+changed the human decision.
+
+## Baselines
+
+For each task, compare three configurations:
+
+- **Baseline A** — model / coding agent modifies the repository directly.
+- **Baseline B** — model produces a patch, human reviews manually.
+- **PrometheOS** — provider produces a governed proposal through the full path.
+
+Measure: correct result, unrelated files changed, regressions introduced, time
+to review, time to repair, number of attempts, cost, evidence completeness,
+recovery quality.
+
+## Success gate (before any new large feature)
+
+- 10 real tasks attempted
+- at least 7 completed correctly
+- zero silent scope violations
+- rollback proven in at least two controlled failures
+- at least three external users
+- at least one user returning for a second repository
+- evidence that review time is lower than the direct-agent baseline
+
+## Packaging note
+
+Internally the command remains `workflow` (generate / dry-run / approve /
+apply / report). The user-facing surface should be renamed around outcomes:
+
+```
+prometheos plan "Fix the parser boundary bug"
+prometheos propose
+prometheos verify
+prometheos approve
+prometheos apply
+prometheos report
+```
+
+## Next: GitHub-native workflow
+
+Once 5–10 real tasks work, build the distribution surface:
+
+```
+GitHub issue
+  -> /prometheos plan
+  -> proposal attached to issue or PR
+  -> dry-run and validation report
+  -> human approval
+  -> branch and draft PR
+```
+
+First GitHub commands: `/prometheos review`, `/prometheos plan`,
+`/prometheos propose`. The app reads an issue, analyzes the repo, creates a
+governed proposal, posts scope / patch summary / risk / validation /
+provenance, and creates a draft PR only after explicit approval. It never
+merges and never runs arbitrary shell from comments.
+
+## Blocker (this environment)
+
+Executing the pilot requires a **reachable model provider** (e.g. OpenRouter,
+LM Studio, Ollama). In the verification environment used to merge #79 there was
+no live endpoint: LM Studio (127.0.0.1:1234) was down and no
+`PROMETHEOS_*`/API key was configured. The real `LlmPatchProvider` path was
+exercised end-to-end against a stub OpenAI-compatible server returning
+JSON-schema edits, confirming the governed workflow routes real provider
+output correctly. To run the 10 real tasks, configure a provider (or point
+`PROMETHEOS_BASE_URL` at a local model server) and supply the first
+"repository you barely know."


### PR DESCRIPTION
Adds the tutorial required after #79 (Safely fix a real bug with PrometheOS Lite) and the Governed Patch Pilot milestone plan (10 real tasks / 5 repos, metrics schema, baselines, success gate, GitHub-native next step).

Note: executing the pilot requires a reachable model provider; the verification environment had none, so the real LlmPatchProvider path was exercised end-to-end against a stub OpenAI-compatible server. See docs/research/governed-patch-pilot.md for the blocker.