### PR TITLE
fix(provider): authenticate workflow generate against OpenRouter

### DIFF
--- a/src/harness/patch_provider.rs
+++ b/src/harness/patch_provider.rs
@@ -859,6 +859,10 @@ impl ProviderRegistry {
             );
         }
 
+        // Authenticate with the OpenRouter API key when set (the env var the
+        // rest of the codebase uses for OpenRouter-compatible providers).
+        let api_key = std::env::var("OPENROUTER_API_KEY").ok();
+
         // Create LLM client from config
         let client = crate::llm::LlmClient::new(&config.base_url, &config.model)
             .map_err(|e| {
@@ -868,7 +872,8 @@ impl ProviderRegistry {
                     Provider: {}\n                    Model: {}\n                    Base URL: {}\n\n                    Error: {}\n\n                    To fix this issue:\n\n                    1. Check that the base URL is correct and accessible\n                    2. Verify the model name matches what the provider supports\n                    3. Ensure the LLM server is running\n                    4. Check network connectivity and firewall settings\n                    5. For local models, verify the server is started with the correct model\n\n                    Example working configurations:\n                    - LM Studio: http://localhost:1234/v1\n                    - Ollama: http://localhost:11434\n                    - OpenAI: https://api.openai.com/v1\n                    ",
                     config.provider, config.model, config.base_url, e
                 )
-            })?;
+            })?
+            .with_api_key(api_key);
 
         Self::with_llm_provider(client, config.model.clone())
     }


### PR DESCRIPTION
## Purpose
Unblock \workflow generate --provider config\ against authenticated providers (OpenRouter). Previously \ProviderRegistry::from_config\ built \LlmClient\ with no API key, so any authenticated endpoint returned 401.

## Change
Read \OPENROUTER_API_KEY\ from the environment and attach it via \LlmClient::with_api_key\ in \rom_config\, mirroring the convention already used in \cli/runtime_builder.rs\. When the variable is absent, \pi_key = None\ and behavior is unchanged (unauthenticated local providers still work).

## Verification
- \cargo clippy --all-targets --all-features -- -D warnings\ passes on this branch.
- \cargo build --bin prometheos\ succeeds.
- Code path exercised end-to-end via the existing \LlmPatchProvider\ integration: the #79 governed-workflow verification ran \generate --provider config\ through a stub OpenAI-compatible server (no key) and confirmed \generate_proposal -> provider.generate() -> gates -> propose_with_meta\ works; with no key the client sends no bearer auth (unchanged).
- No unit test for provider auth exists; this is a minimal unblocker, not a feature.

## Known limitation (out of scope)
\rom_config\ hardcodes the OpenRouter-named key. Other authenticated providers (OpenAI, etc.) would need provider-specific variables (\OPENAI_API_KEY\, \PROMETHEOS_API_KEY\). Not broadened here. Also note: \LlmClient\ posts to \{base_url}/v1/chat/completions\, so \ase_url\ should be the part *before* \/v1/chat/completions\ (e.g. \https://openrouter.ai/api\).