### PR TITLE
fix(llm): normalize OpenAI-compatible chat endpoint

### DIFF
--- a/src/cli/commands/workflow.rs
+++ b/src/cli/commands/workflow.rs
@@ -15,7 +15,9 @@ use prometheos_lite::config::AppConfig;
 use prometheos_lite::harness::patch_provider::{
     MockProposalMode, MockProposalProvider, PatchProvider, PatchProviderContext, ProviderRegistry,
 };
-use prometheos_lite::workflow::{self, AuthorityLevel, GenerateScope, ProviderRouteInfo, sanitize_provider_route};
+use prometheos_lite::workflow::{
+    self, AuthorityLevel, GenerateScope, ProviderRouteInfo, sanitize_provider_route,
+};
 
 /// Map a string (e.g. from `PROMETHEOS_MOCK_MODE`) to a mock provider mode.
 fn provider_mode_from_str(s: &str) -> MockProposalMode {

--- a/src/llm/client/llm_client.rs
+++ b/src/llm/client/llm_client.rs
@@ -8,6 +8,22 @@ use reqwest::Client;
 use super::types::{ChatCompletionRequest, ChatCompletionResponse};
 use crate::config::AppConfig;
 
+/// Normalize an OpenAI-compatible base URL into the chat completions endpoint.
+///
+/// Accepts the conventional `/v1`-suffixed base (e.g. `https://openrouter.ai/api/v1`)
+/// as well as a legacy base without `/v1` (e.g. `https://openrouter.ai/api`). Any
+/// query string or fragment is dropped: chat endpoints authenticate via the
+/// `Authorization` header, not the URL.
+fn chat_completions_url(base_url: &str) -> String {
+    let without_query = base_url.split(['?', '#']).next().unwrap_or(base_url);
+    let base = without_query.trim_end_matches('/');
+    if base.ends_with("/v1") {
+        format!("{base}/chat/completions")
+    } else {
+        format!("{base}/v1/chat/completions")
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct LlmClient {
     http: Client,
@@ -59,9 +75,7 @@ impl LlmClient {
         let mut last_error = None;
 
         for attempt in 0..=self.max_retries {
-            let mut request_builder = self
-                .http
-                .post(format!("{}/v1/chat/completions", self.base_url));
+            let mut request_builder = self.http.post(chat_completions_url(&self.base_url));
             if let Some(api_key) = self.api_key.as_deref() {
                 request_builder = request_builder.bearer_auth(api_key);
             }
@@ -126,9 +140,7 @@ impl LlmClient {
             stream: true,
         };
 
-        let mut request_builder = self
-            .http
-            .post(format!("{}/v1/chat/completions", self.base_url));
+        let mut request_builder = self.http.post(chat_completions_url(&self.base_url));
         if let Some(api_key) = self.api_key.as_deref() {
             request_builder = request_builder.bearer_auth(api_key);
         }
@@ -168,5 +180,60 @@ impl LlmClient {
         }
 
         Ok(full_content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_chat_completions_endpoint() {
+        let cases = [
+            (
+                "https://openrouter.ai/api/v1",
+                "https://openrouter.ai/api/v1/chat/completions",
+            ),
+            (
+                "https://openrouter.ai/api/v1/",
+                "https://openrouter.ai/api/v1/chat/completions",
+            ),
+            (
+                "https://openrouter.ai/api",
+                "https://openrouter.ai/api/v1/chat/completions",
+            ),
+            (
+                "https://api.openai.com/v1",
+                "https://api.openai.com/v1/chat/completions",
+            ),
+            (
+                "http://localhost:1234/v1",
+                "http://localhost:1234/v1/chat/completions",
+            ),
+            (
+                "http://localhost:11434",
+                "http://localhost:11434/v1/chat/completions",
+            ),
+        ];
+
+        for (base, expected) in cases {
+            assert_eq!(chat_completions_url(base), expected, "base = {base}");
+        }
+    }
+
+    #[test]
+    fn drops_query_string_and_fragment() {
+        assert_eq!(
+            chat_completions_url("https://example.com/v1?token=x"),
+            "https://example.com/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_url("https://example.com/v1#frag"),
+            "https://example.com/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_url("https://example.com/api?token=x"),
+            "https://example.com/api/v1/chat/completions"
+        );
     }
 }

--- a/tests/provider_governed_proposal_tests.rs
+++ b/tests/provider_governed_proposal_tests.rs
@@ -427,10 +427,20 @@ async fn windows_drive_path_rejected() {
     let (_d, repo) = temp_repo();
     let provider = MockProposalProvider::with_mode(MockProposalMode::WindowsDrive);
     let r = workflow::generate_proposal(
-        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), None, None,
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
     )
     .await;
-    assert!(r.is_err(), "Windows drive path must be rejected on every platform");
+    assert!(
+        r.is_err(),
+        "Windows drive path must be rejected on every platform"
+    );
 }
 
 // 16. UNC provider paths are rejected (even on Linux CI)
@@ -439,7 +449,14 @@ async fn unc_path_rejected() {
     let (_d, repo) = temp_repo();
     let provider = MockProposalProvider::with_mode(MockProposalMode::Unc);
     let r = workflow::generate_proposal(
-        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), None, None,
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
     )
     .await;
     assert!(r.is_err(), "UNC path must be rejected on every platform");
@@ -451,7 +468,14 @@ async fn plain_text_rejected_before_artifact() {
     let (_d, repo) = temp_repo();
     let provider = MockProposalProvider::with_mode(MockProposalMode::PlainText);
     let r = workflow::generate_proposal(
-        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), None, None,
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        None,
+        None,
     )
     .await;
     assert!(r.is_err(), "plain text must not be persisted as a proposal");
@@ -471,7 +495,14 @@ async fn secret_bearing_route_is_sanitized() {
         route: Some("https://sk-SECRETKEY123@api.example.com/v1/models?key=zzz#frag".to_string()),
     };
     let res = workflow::generate_proposal(
-        &repo, "g", AuthorityLevel::Assist, &provider, ctx("g"), &safe_scope(), Some(route), None,
+        &repo,
+        "g",
+        AuthorityLevel::Assist,
+        &provider,
+        ctx("g"),
+        &safe_scope(),
+        Some(route),
+        None,
     )
     .await
     .expect("generate should succeed");
@@ -482,12 +513,21 @@ async fn secret_bearing_route_is_sanitized() {
         .as_str()
         .expect("route present")
         .to_string();
-    assert_eq!(route_json, "https://api.example.com", "route must be scheme://host only");
-    assert!(!route_json.contains("sk-SECRETKEY123"), "userinfo secret must be stripped");
+    assert_eq!(
+        route_json, "https://api.example.com",
+        "route must be scheme://host only"
+    );
+    assert!(
+        !route_json.contains("sk-SECRETKEY123"),
+        "userinfo secret must be stripped"
+    );
     assert!(!route_json.contains("/v1"), "path must be stripped");
     assert!(!route_json.contains("key=zzz"), "query must be stripped");
     assert!(!route_json.contains("#frag"), "fragment must be stripped");
-    assert!(!report.to_lowercase().contains("sk-secretkey123"), "no secret anywhere in report");
+    assert!(
+        !report.to_lowercase().contains("sk-secretkey123"),
+        "no secret anywhere in report"
+    );
 }
 
 // 19. sanitize_provider_route keeps only scheme://host[:port]
@@ -512,16 +552,19 @@ async fn report_exposes_lifecycle_evidence() {
     let res = generate_safe(&repo).await;
     workflow::dry_run(&repo, &res.id, Some("true")).expect("dry-run should pass");
     workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
-    workflow::apply(&repo, &res.id, &res.patch_hash, Some("true"), true).expect("apply should pass");
+    workflow::apply(&repo, &res.id, &res.patch_hash, Some("true"), true)
+        .expect("apply should pass");
 
     let report = workflow::report(&repo, &res.id).expect("report should succeed");
     let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
     assert_eq!(value["dry_run_validation"], "true");
     assert_eq!(value["apply_validation"], "true");
-    assert!(value["checkpoint_ref"]
-        .as_str()
-        .unwrap_or("")
-        .starts_with("prometheos/checkpoint-"));
+    assert!(
+        value["checkpoint_ref"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("prometheos/checkpoint-")
+    );
     assert_eq!(value["rollback_status"], "clean");
     assert_eq!(value["applied"], true);
 }
@@ -535,22 +578,18 @@ async fn rollback_outcome_recorded() {
     workflow::approve(&repo, &res.id, &res.patch_hash, "op").expect("approve should pass");
 
     // Apply with a validation command that fails -> must roll back and record status.
-    let applied = workflow::apply(
-        &repo,
-        &res.id,
-        &res.patch_hash,
-        Some("false"),
-        true,
-    );
+    let applied = workflow::apply(&repo, &res.id, &res.patch_hash, Some("false"), true);
     assert!(applied.is_err(), "apply must fail validation and roll back");
 
     let report = workflow::report(&repo, &res.id).expect("report should succeed");
     let value: serde_json::Value = serde_json::from_str(&report).expect("valid json");
     assert_eq!(value["rollback_status"], "rolled_back");
-    assert!(value["checkpoint_ref"]
-        .as_str()
-        .unwrap_or("")
-        .starts_with("prometheos/checkpoint-"));
+    assert!(
+        value["checkpoint_ref"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("prometheos/checkpoint-")
+    );
     // Tree reverted to original (no generated file).
     assert!(!repo.join("src/generated_patch.rs").exists());
 }


### PR DESCRIPTION
## Problem
`LlmClient` posted to `{base_url}/v1/chat/completions`. A conventional OpenAI-compatible base ending in `/v1` (e.g. `https://openrouter.ai/api/v1`) therefore produced a malformed double-`/v1` URL (`.../api/v1/v1/chat/completions`), causing 404s even with a valid key.

## Fix
Add a single `chat_completions_url` normalizer that:
- accepts a base ending in `/v1` (OpenRouter, OpenAI, local models) and appends `/chat/completions`;
- accepts a legacy base without `/v1` and appends `/v1/chat/completions`;
- drops any query string or fragment (chat endpoints auth via the Authorization header, not the URL).

Replaces both `format!({}/v1/chat/completions, self.base_url)` call sites.

## Verification
- `cargo fmt --check` passes (includes formatting-only fixes for pre-existing #79 violations in workflow.rs and provider_governed_proposal_tests.rs).
- `cargo clippy --all-targets --all-features -- -D warnings` passes.
- `cargo test` passes, including new table-driven tests for `chat_completions_url` (with/without /v1, trailing slash, localhost, and query/fragment stripping).

## Scope
Limited to `src/llm/client/llm_client.rs` (+ formatting cleanups noted above). Not a routing framework; one normalization function only.