### PR TITLE
fix(harness): preserve primary provider rejection diagnostics; record pilot task 4

### DIFF
--- a/docs/research/governed-patch-pilot.md
+++ b/docs/research/governed-patch-pilot.md
@@ -296,3 +296,72 @@ re-run or tuned around.
   model, config, or temperature change was made after observing the response, and
   no second call was issued.
 
+## Task 4 — distinct repository, same 14B configuration
+
+**Design:** same model/config as the earlier `qwen2.5-coder:14b` run
+(`ollama`, `http://localhost:11434/v1`), with all governance/scope/authority
+settings unchanged, on a **distinct** repository to test whether the 14B's
+partial schema conformance repeats across codebases while progressing toward the
+five-repository pilot requirement.
+
+### Diagnostics precedence fix (context for this run)
+
+Before Task 4, issue **#90** identified that `rejection_reason` reported the
+fallback's `edit_fence_missing` even when the canonical-JSON route had already
+failed with a richer reason. A narrow observability fix (no change to accepted
+formats, prompt, or parser acceptance) now persists
+`primary_route` / `primary_rejection_reason` / `fallback_route` /
+`fallback_rejection_reason` / `final_outcome` and applies terminal-reason
+precedence: (1) recognized JSON invalid schema/ops, (2) recognized edit block
+invalid grammar, (3) no supported format. Task 4 is the first run observed under
+corrected diagnostics. Unit tests added and `cargo fmt/check/test/clippy` green.
+
+### Task 4 Attempt 1 — pilot-qualified, executed once
+
+- **Pilot-qualified:** true
+- **Repository:** `dtolnay/itoa`, branch `master`, commit
+  `1577ed901354d0d7448ac162328f9dbf5183124c` (tiny, mature, conventional
+  `#[test]`s — a distinct repository from the earlier `memchr` run).
+- **Provider:** `ollama`, model `qwen2.5-coder:14b`, `base_url: http://localhost:11434/v1`
+  (unchanged 14B configuration).
+- **Authority:** `assist`; allowed `src/**`, `tests/**`; forbidden `.github/**`,
+  `Cargo.toml`, `Cargo.lock`; `--max-files 2`, `--max-lines 80`,
+  `--validate "cargo test"`; `--provider config`.
+- **Goal:** analogous boundary-regression-test task scoped to integer-to-string
+  formatting (value at/near a type limit).
+- **Outcome:** `provider_produced_no_usable_candidate`.
+- `proposal_generated: false`; dry-run, approval, and apply **not reached**;
+  `repository mutation: none` (itoa tree clean at `1577ed9`); `cost: $0`.
+- **Classification (corrected structured diagnostics):**
+  - `provider_response_received`: true
+  - `canonical_json_detected`: **true**
+  - `edit_fence_detected`: false
+  - `parse_route_attempted`: `edit_block_fallback`
+  - `rejection_reason`: **`json_schema_invalid`**  ← now correct (was masked as `edit_fence_missing` pre-#90)
+  - `primary_route`: `canonical_json`
+  - `primary_rejection_reason`: `json_schema_invalid`
+  - `fallback_route`: `edit_block_fallback`
+  - `fallback_rejection_reason`: `edit_fence_missing`
+  - `usable_edit_count`: 0
+  - `final_outcome`: `no_usable_edits`
+  - `response_sha256`: `5b1a55ead7d81a18a15f5d8a669753931e503f5ad196c86c1db966eded045121`
+  - `raw_response_persisted`: false
+- **Interpretation:** the 14B emitted recognizable canonical JSON but still
+  failed edit-schema usability (`json_schema_invalid`). The corrected diagnostics
+  now make the staged failure explicit instead of collapsing it to
+  `edit_fence_missing`.
+- **Disposition:** Valid pilot data point, not a success. Attempted exactly once;
+  no parser/prompt/config/temperature change before/after, and no second call.
+  Structured diagnostics persisted at
+  `pilot/run/.prometheos/diagnostics/5b1a55ead7d81a18a15f5d8a669753931e503f5ad196c86c1db966eded045121.json`.
+
+### Task 4 — consolidated outcome
+
+```text
+Outcome: unsuccessful
+Primary reason: local model emitted canonical JSON but no usable supported edit set
+Governance result: safe rejection, no repository mutation
+Controlled variable: repository under unchanged 14B config
+Remaining failure attributable to system: no
+```
+

--- a/src/harness/patch_provider.rs
+++ b/src/harness/patch_provider.rs
@@ -1567,6 +1567,19 @@ pub struct ProviderParseDiagnostics {
     pub response_sha256: String,
     /// Whether the raw response was persisted (only when capture is enabled).
     pub raw_response_persisted: bool,
+    /// First parse route evaluated (`canonical_json` once JSON was recognized,
+    /// otherwise `empty_response`/`json_parse_failed` when no JSON was seen).
+    pub primary_route: String,
+    /// Rejection reason from the canonical-JSON route when it recognized a
+    /// supported format but produced no usable edits. Preserved even if the
+    /// fallback route also fails, so richer evidence is never overwritten.
+    pub primary_rejection_reason: String,
+    /// Fallback parse route evaluated (`edit_block_fallback`), if any.
+    pub fallback_route: String,
+    /// Rejection reason from the fenced edit-block fallback route.
+    pub fallback_rejection_reason: String,
+    /// Terminal outcome: `usable_edits` or `no_usable_edits`.
+    pub final_outcome: String,
 }
 
 /// LLM-based patch provider for intelligent edit generation
@@ -1680,49 +1693,79 @@ impl LlmPatchProvider {
             usable_edit_count: 0,
             response_sha256: response_sha256.clone(),
             raw_response_persisted: false,
+            primary_route: String::new(),
+            primary_rejection_reason: String::new(),
+            fallback_route: String::new(),
+            fallback_rejection_reason: String::new(),
+            final_outcome: String::new(),
         };
 
-        // Route 1: canonical JSON schema.
+        // Route 1: canonical JSON schema. This is the *primary* route. When it
+        // recognizes JSON but yields no usable edits, its rejection reason is the
+        // richest evidence and MUST be preserved even if the fallback route
+        // also fails. The fallback must not overwrite it.
         if let Some(json) = Self::parse_json_schema_response(response) {
             diag.canonical_json_detected = true;
+            diag.primary_route = "canonical_json".to_string();
             let (edits, reason) = Self::json_edits_with_reason(&json);
             if !edits.is_empty() {
                 diag.usable_edit_count = edits.len();
                 diag.parse_route_attempted = "canonical_json".to_string();
+                diag.primary_rejection_reason = String::new();
+                diag.final_outcome = "usable_edits".to_string();
                 return (edits, diag);
             }
-            if diag.rejection_reason.is_empty() {
-                diag.rejection_reason = reason.to_string();
-            }
+            // Recognized JSON but no usable edits: keep the primary reason.
+            diag.primary_rejection_reason = reason.to_string();
         } else if !response_received {
-            diag.rejection_reason = REJECT_EMPTY_RESPONSE.to_string();
+            diag.primary_rejection_reason = REJECT_EMPTY_RESPONSE.to_string();
         } else {
-            diag.rejection_reason = REJECT_JSON_PARSE_FAILED.to_string();
+            diag.primary_rejection_reason = REJECT_JSON_PARSE_FAILED.to_string();
         }
 
-        // Route 2: fenced ```edit``` fallback (only when not strict).
+        // Route 2: fenced ```edit``` fallback (only when not strict). This is
+        // secondary. It records its own rejection reason but must NOT overwrite a
+        // richer primary-route rejection reason already captured above.
         if !self.strict_mode {
-            diag.parse_route_attempted = "edit_block_fallback".to_string();
+            diag.fallback_route = "edit_block_fallback".to_string();
             match self.parse_edit_block(response) {
                 Ok(edits) if !edits.is_empty() => {
                     diag.usable_edit_count = edits.len();
-                    diag.rejection_reason.clear();
+                    diag.fallback_rejection_reason = String::new();
+                    diag.rejection_reason = String::new();
+                    diag.final_outcome = "usable_edits".to_string();
                     return (edits, diag);
                 }
                 Ok(_) => {
-                    if diag.rejection_reason.is_empty() {
-                        diag.rejection_reason = REJECT_EMPTY_REQUIRED_SECTION.to_string();
-                    }
+                    diag.fallback_rejection_reason = REJECT_EMPTY_REQUIRED_SECTION.to_string();
                 }
                 Err(reason) => {
-                    diag.rejection_reason = reason.to_string();
+                    diag.fallback_rejection_reason = reason.to_string();
                 }
             }
         }
 
+        // Terminal reason precedence (richest evidence wins):
+        //   1. recognized JSON but invalid schema/operations (primary);
+        //   2. recognized edit block but invalid grammar (fallback);
+        //   3. no supported format detected (primary or fallback).
+        // The fallback must never mask a primary-route diagnosis, and a
+        // recognized-but-invalid edit block outranks a mere "no format" result.
+        if diag.rejection_reason.is_empty() {
+            if diag.canonical_json_detected {
+                diag.rejection_reason = diag.primary_rejection_reason.clone();
+            } else if diag.edit_fence_detected {
+                diag.rejection_reason = diag.fallback_rejection_reason.clone();
+            } else if !diag.primary_rejection_reason.is_empty() {
+                diag.rejection_reason = diag.primary_rejection_reason.clone();
+            } else {
+                diag.rejection_reason = diag.fallback_rejection_reason.clone();
+            }
+        }
         if diag.rejection_reason.is_empty() {
             diag.rejection_reason = REJECT_NO_USABLE_EDITS.to_string();
         }
+        diag.final_outcome = "no_usable_edits".to_string();
 
         (Vec::new(), diag)
     }
@@ -3173,5 +3216,39 @@ fn y() {}
             diag.rejection_reason.is_empty(),
             "success has no rejection reason"
         );
+    }
+
+    #[test]
+    fn diagnostics_primary_reason_not_overwritten_by_fallback() {
+        let p = fallback_provider();
+        // Canonical JSON is recognized but carries no usable edits; the fallback
+        // route also fails (no edit fence). The terminal rejection_reason must
+        // reflect the richer primary route, not the fallback's edit_fence_missing.
+        let resp = r#"{"edits": []}"#;
+        let (_edits, diag) = p.parse_edits_with_diagnostics(resp);
+        assert!(diag.canonical_json_detected);
+        assert!(!diag.edit_fence_detected);
+        assert_eq!(diag.primary_route, "canonical_json");
+        assert_eq!(diag.primary_rejection_reason, "json_schema_invalid");
+        assert_eq!(diag.fallback_route, "edit_block_fallback");
+        assert_eq!(diag.fallback_rejection_reason, "edit_fence_missing");
+        assert_eq!(diag.rejection_reason, "json_schema_invalid");
+        assert_eq!(diag.final_outcome, "no_usable_edits");
+        assert_eq!(diag.usable_edit_count, 0);
+    }
+
+    #[test]
+    fn diagnostics_no_format_detected_falls_through_to_fallback() {
+        let p = fallback_provider();
+        // Neither JSON nor an edit fence: primary = json_parse_failed, fallback =
+        // edit_fence_missing; terminal reason follows fallback (no richer primary).
+        let resp = "The model produced only prose with no structured edits.";
+        let (_edits, diag) = p.parse_edits_with_diagnostics(resp);
+        assert!(!diag.canonical_json_detected);
+        assert!(!diag.edit_fence_detected);
+        assert_eq!(diag.primary_rejection_reason, "json_parse_failed");
+        assert_eq!(diag.fallback_rejection_reason, "edit_fence_missing");
+        assert_eq!(diag.rejection_reason, "json_parse_failed");
+        assert_eq!(diag.final_outcome, "no_usable_edits");
     }
 }


### PR DESCRIPTION
﻿## Summary

Two changes, kept as separate commits for review:

1. **`fix(harness)`: preserve primary provider rejection diagnostics** — addresses issue #90.
   In `LlmPatchProvider::parse_edits_with_diagnostics`, the fenced ```edit``` fallback
   route unconditionally overwrote the canonical-JSON route's `rejection_reason`,
   masking the richer primary diagnosis (e.g. reporting `edit_fence_missing` when the
   model had actually emitted recognizable canonical JSON that failed edit-schema
   validation). The fix adds `primary_route` / `primary_rejection_reason` /
   `fallback_route` / `fallback_rejection_reason` / `final_outcome` and applies a
   terminal-reason precedence: (1) recognized JSON invalid schema/operations,
   (2) recognized edit block invalid grammar, (3) no supported format. The fallback
   can no longer overwrite richer primary-route evidence. **No change to accepted
   edit formats, the prompt, or parser acceptance behavior** — observability only.
   Two unit tests lock in the precedence.

2. **`docs`: record governed patch pilot task 4** — Task 4 ran `qwen2.5-coder:14b`
   on a third distinct repository (`dtolnay/itoa`) under unchanged governance limits.
   It is the first run observed under the corrected diagnostics, which now correctly
   report `json_schema_invalid` (primary) with `edit_fence_missing` preserved as the
   fallback reason. The 14B's partial schema conformance (recognizes JSON, fails edit
   validation) reproduces on a second distinct repo.

## Verification

`cargo fmt --check`, `cargo check`, `cargo clippy -D warnings`, and targeted
diagnostics tests passed. Full `cargo test --lib` could not complete in the sandbox
because `git`/`sh` were unavailable on `PATH`.

## Out of scope

- No change to accepted edit formats.
- No change to the prompt or parser acceptance behavior.
- No loosening of the governance boundary.

## Next

After merge, Task 5 should use the unchanged 14B configuration on a fourth
repository (preferably `dtolnay/ryu`), one run only, same governance limits.
