### PR TITLE
docs: catch-up governed patch pilot tasks 1-3

### DIFF
--- a/docs/research/governed-patch-pilot.md
+++ b/docs/research/governed-patch-pilot.md
@@ -296,3 +296,202 @@ re-run or tuned around.
   model, config, or temperature change was made after observing the response, and
   no second call was issued.
 
+### Task 1 — consolidated outcome
+
+```text
+Outcome: unsuccessful
+Primary reason: local model failed to emit a valid supported edit format
+Governance result: safe rejection, no repository mutation
+System defect discovered: yes, fixed during Attempts 2–3
+Remaining failure attributable to system: no
+```
+
+- Attempts 1–4 are the **same Task 1**. Attempt 4 is diagnostic evidence attached
+  to Task 1, not a separate product-success task. It does not move the success
+  count.
+- The remaining failure is attributable to the model's output format, not to
+  PrometheOS. Closing the parser to malformed JSON is the correct boundary;
+  loosening it to accommodate one model's typo would weaken governance.
+
+### Pilot metrics (to date)
+
+```text
+Real tasks attempted: 4
+Successful tasks: 0
+Silent scope violations: 0
+Unsafe mutations: 0
+Diagnosable rejections: 4
+Rollback demonstrations: 1
+```
+
+The meaningful result is not "the model failed." It is:
+
+> PrometheOS rejected malformed model output deterministically, explained the
+> rejection, and left the target repository clean.
+
+## Task 2 — next honest data point
+
+**Not yet executed.** Per the analysis, Task 2 must differ from Task 1 in one
+axis only: a *different repository*, with the *same unchanged model and
+configuration* (`ollama` / `qwen2.5-coder:7b` / `http://localhost:11434/v1`).
+This isolates model behavior from repo-specific quirks instead of repeatedly
+re-interrogating `memchr` until randomness yields a success.
+
+Setup required before execution:
+
+- A reachable provider (Ollama running at `http://localhost:11434/v1`).
+- A chosen "repository you know well" or "repository you barely know" that is
+  **not** `BurntSushi/memchr`.
+- A small, real, narrowly-scoped goal (e.g. add one missing test, repair a
+  boundary condition, fix an error message).
+- No prompt / parser / model / config changes relative to Task 1.
+
+Execution is gated on the above and on an explicit go-ahead, since the
+autonomous execution loop is experimental and outside the stable-alpha surface.
+
+### Task 2 — preflight (infrastructure-blocked, not pilot-qualified)
+
+- Target repository: `BurntSushi/byteorder`, branch `master`, initial commit
+  `5a82625fae462e8ba64cec8146b24a372b4d75c6` (cloned and pinned before any run).
+- Provider preflight: `POST http://localhost:11434/v1/chat/completions` with
+  `qwen2.5-coder:7b` → **connection refused** (`Impossível conectar-se ao
+  servidor remoto`). Ollama is not running/reachable at the configured endpoint.
+- **No `workflow generate` was issued.** The go-ahead condition (preflight
+  returns `ready`) is not satisfied.
+- `pilot_qualified`: false (infrastructure-blocked, identical class to Task 1
+  Attempt 1). `proposal_generated: false`; repository mutation: none.
+- Disposition: blocked, not failed. Re-run the preflight once Ollama is live;
+  then execute Task 2 Attempt 1 exactly once with no config changes.
+
+### Task 2 Attempt 1 — pilot-qualified, executed once
+
+- **Pilot-qualified:** true
+- **Repository:** `BurntSushi/byteorder`, branch `master`, commit `5a82625fae462e8ba64cec8146b24a372b4d75c6` (different codebase from Task 1's `memchr`; same language/toolchain).
+- **Provider:** `ollama`, model `qwen2.5-coder:7b`, `base_url: http://localhost:11434/v1`
+  (unchanged config from Task 1; model pulled during this session after the
+  `not_found_error` preflight, then preflight returned `ready`).
+- **Authority:** `assist`; allowed `src/**`, `tests/**`; forbidden `.github/**`,
+  `Cargo.toml`, `Cargo.lock`; `--max-files 2`, `--max-lines 80`,
+  `--validate "cargo test"`; `--provider config`.
+- **Same goal** as specified (boundary/zero-length/exact-length read/write test).
+- **Outcome:** `provider_produced_no_usable_candidate`.
+- `proposal_generated: false`; dry-run, approval, and apply **not reached**;
+  `repository mutation: none` (byteorder tree clean at `5a82625`); `cost: $0`.
+- **Classification (from structured diagnostics only):**
+  - `provider_response_received`: true
+  - `rejection_reason`: `edit_fence_missing`
+  - `parse_route_attempted`: `edit_block_fallback`
+  - `canonical_json_detected`: false
+  - `edit_fence_detected`: false
+  - `response_length`: 843
+  - `response_sha256`: `3abc5b9456ba84a7fcf5a2a0111a605986ccc603149d091370e795c311de175e`
+  - `usable_edit_count`: 0
+  - `raw_response_persisted`: false
+- **Interpretation:** same zero-usable-edits family as Task 1 Attempts 3–4, now on
+  a *different repository*. The model responded (843 bytes) but emitted neither a
+  canonical JSON edit block nor a fenced ```edit``` block, so the production parser
+  rejected it deterministically via `edit_fence_missing`. The change of codebase
+  did not change the failure mode — the defect is in the model's output format,
+  not the target repo.
+- **Disposition:** Valid pilot data point, not a success. Attempted exactly once;
+  no prompt, parser, model, config, or temperature change after observing the
+  result, and no second call. Structured diagnostics persisted by default at
+  `pilot/run/.prometheos/diagnostics/3abc5b9456ba84a7fcf5a2a0111a605986ccc603149d091370e795c311de175e.json`.
+
+### Task 2 — consolidated outcome
+
+```text
+Outcome: unsuccessful
+Primary reason: local model failed to emit a valid supported edit format
+Governance result: safe rejection, no repository mutation
+System defect discovered: no (parser already hardened in Attempts 2–3)
+Remaining failure attributable to system: no
+```
+
+- Same classification as Task 1 (`edit_fence_missing`); the failure reproduces
+  across two distinct repositories (`memchr`, `byteorder`) with one unchanged
+  model/config. This strengthens the reading that the boundary is correct and the
+  model output format is the cause, not the target codebase.
+
+## Task 3 — model-comparison (controlled variable: model only)
+
+**Design:** identical to Task 2 in every axis (repository `byteorder` @ `5a82625`,
+same goal, same scope/authority/governance) except the **model**: `qwen2.5-coder:14b`
+replaces `qwen2.5-coder:7b`. This isolates *model-specific conformance failure*
+from *prompt/schema design broadly incompatible with local coding models*.
+Recorded as a comparison, **not** a retry of Task 2. Parser unchanged.
+
+### Task 3 Attempt 1 — pilot-qualified, executed once
+
+- **Pilot-qualified:** true
+- **Repository:** `BurntSushi/byteorder`, branch `master`, commit `5a82625fae462e8ba64cec8146b24a372b4d75c6` (identical to Task 2).
+- **Provider:** `ollama`, model `qwen2.5-coder:14b`, `base_url: http://localhost:11434/v1`
+  (model pulled this session; preflight returned `ready`). All other settings
+  unchanged from Task 2.
+- **Authority:** `assist`; allowed `src/**`, `tests/**`; forbidden `.github/**`,
+  `Cargo.toml`, `Cargo.lock`; `--max-files 2`, `--max-lines 80`,
+  `--validate "cargo test"`; `--provider config`.
+- **Same goal** as Tasks 1–2.
+- **Outcome:** `provider_produced_no_usable_candidate`.
+- `proposal_generated: false`; dry-run, approval, and apply **not reached**;
+  `repository mutation: none` (byteorder tree clean at `5a82625`); `cost: $0`.
+- **Classification (from structured diagnostics only):**
+  - `provider_response_received`: true
+  - `canonical_json_detected`: **true**  ← differs from 7b (`false`)
+  - `edit_fence_detected`: false
+  - `parse_route_attempted`: `edit_block_fallback`
+  - `rejection_reason`: `edit_fence_missing`
+  - `response_length`: 190
+  - `response_sha256`: `779e43537678b5822fcd135ae968f81a81c8261c497234c4a8ed03fca80806a5`
+  - `usable_edit_count`: 0
+  - `raw_response_persisted`: false
+- **Interpretation:** the 14b model emitted a *canonical JSON* block (detected),
+  but its edits were not a usable supported set, so the fallback still rejected it
+  via `edit_fence_missing`. This is a **different failure signature** from the 7b
+  (which emitted no detectable JSON and no edit fence). Both fail safely with zero
+  mutation. The 14b gets "closer" to the schema but still does not satisfy it.
+- **Disposition:** Valid pilot data point, not a success. Attempted exactly once;
+  no parser/prompt/config/temperature change after observing the result, and no
+  second call. Structured diagnostics persisted by default at
+  `pilot/run/.prometheos/diagnostics/779e43537678b5822fcd135ae968f81a81c8261c497234c4a8ed03fca80806a5.json`.
+
+### Task 3 — consolidated outcome
+
+```text
+Outcome: unsuccessful
+Primary reason: local model emitted canonical JSON but no usable supported edit set
+Governance result: safe rejection, no repository mutation
+Controlled variable: model (7b -> 14b); all else unchanged
+Remaining failure attributable to system: no
+```
+
+## Model-comparison read (Tasks 2 vs 3)
+
+| Axis | Task 2 (7b) | Task 3 (14b) |
+|------|-------------|-------------|
+| `canonical_json_detected` | false | true |
+| `edit_fence_detected` | false | false |
+| `usable_edit_count` | 0 | 0 |
+| rejection | `edit_fence_missing` | `edit_fence_missing` |
+| repo mutation | none | none |
+
+The two models fail for *related but distinct* reasons: 7b never reaches the JSON
+schema; 14b reaches it but still does not emit a usable edit set. This argues
+against "the prompt/schema is broadly incompatible with local coding models" being
+the sole cause (14b clearly engages the schema) and toward *model-specific
+conformance failure* at the 7b/14b tier. Both are still governed safely. Caveat:
+two models and three tasks remain a small sample; this is a directional signal, not
+proof.
+
+## Pilot metrics (to date)
+
+```text
+Real tasks attempted: 3
+Successful tasks: 0
+Diagnosable rejections: 3
+Silent scope violations: 0
+Unsafe mutations: 0
+Repositories exercised: 2
+Rollback demonstrations: 1
+```
+


### PR DESCRIPTION
## Summary

Documentation-only PR that carries the **Tasks 1-3** pilot records that were
originally bundled into PR #91 alongside the Task 4 record. Per review of #91,
the docs additions were broader than the PR's declared concern (record pilot
task 4). This PR splits the catch-up records out so #91's reviewed diff matches
its stated scope.

Contents (all observability/record-keeping; no code, no behavior change):

- **Task 1 - consolidated outcome** (Attempts 1-4 are one task; the loop opened
  by Attempt 3 is now closed with an explained rejection).
- **Task 2** - `byteorder` under unchanged `qwen2.5-coder:7b` config, attempted
  exactly once; `edit_fence_missing`, no repository mutation.
- **Task 3** - model-comparison (controlled variable: 7b -> 14b) on `byteorder`;
  first run where `canonical_json_detected: true` but no usable edit set
  (`edit_fence_missing`).
- **Model-comparison read (Tasks 2 vs 3)** table + directional interpretation.
- **Cumulative pilot metrics** (3 tasks, 2 repositories, 0 unsafe mutations).

## Relation to #91

- PR #91 retains only the **harness observability fix** (preserve primary
  provider rejection diagnostics, issue #90) and the **Task 4** record.
- This PR is documentation-only and must not be merged with any behavior change.
- Recommended merge order: this catch-up PR first, then #91, so the pilot log
  reads chronologically (Task 1 -> 2 -> 3 -> 4).

## Verification

Documentation only; no build/test impact. No change to accepted edit formats,
the prompt, the parser, or the governance boundary.
