### PR TITLE
fix(workflow): normalize create-file diff headers

### DIFF
--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -895,9 +895,11 @@ fn render_two_sides(rel_str: &str, old: Option<&str>, new: Option<&str>) -> Resu
 /// Normalize `git diff --no-index` headers (`a/o/<rel>` / `b/n/<rel>`) to
 /// `a/<rel>` / `b/<rel>` and force forward slashes.
 fn rewrite_diff_header(raw: &str) -> String {
-    raw.replace("a/o/", "a/")
+    raw.replace('\\', "/")
+        .replace("a/o/", "a/")
+        .replace("b/o/", "b/")
+        .replace("a/n/", "a/")
         .replace("b/n/", "b/")
-        .replace('\\', "/")
 }
 
 /// Apply a provider `SearchReplace` edit to file text. An empty search prepends
@@ -1982,6 +1984,39 @@ mod render_diagnostics_tests {
             "search_replace",
             "src/existing.rs",
         );
+    }
+
+    #[test]
+    fn create_file_renders_without_leaked_temp_prefix() {
+        // Regression test for the leaked `a/n/` / `b/n/` temp path segments
+        // that `git diff --no-index` emits for create-file operations. The
+        // renderer must normalize create-file headers to repo-relative
+        // `a/<rel>` / `b/<rel>` and never leak the temporary `o/` or `n/`
+        // prefixes used inside the OS temp directory.
+        let raw = "\
+diff --git a/n/tests/foo.rs b/n/tests/foo.rs\n\
+new file mode 100644\n\
+index 0000000..7f869ab\n\
+--- /dev/null\n\
++++ b/n/tests/foo.rs\n\
+@@ -0,0 +1,2 @@\n\
++use foo;\n\
++";
+        let out = crate::workflow::rewrite_diff_header(raw);
+        assert!(
+            out.contains("--- /dev/null"),
+            "create-file old side must be /dev/null, got:\n{out}"
+        );
+        assert!(
+            out.contains("+++ b/tests/foo.rs"),
+            "create-file new side must be b/tests/foo.rs, got:\n{out}"
+        );
+        for bad in ["a/n/", "b/n/", "a/o/", "b/o/"] {
+            assert!(
+                !out.contains(bad),
+                "leaked temp prefix {bad} in rendered header:\n{out}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

ewrite_diff_header (src/workflow/mod.rs) normalized only part of the
temporary path namespace that ender_two_sides produces via
git diff --no-index. For a create-file operation the old side is /dev/null
and the new side is written to a temp file at 
/<rel>, so git emits:

`diff
--- /dev/null
+++ b/n/<path>
`

plus a diff --git a/n/<path> b/n/<path> line. The prior normalizer
only stripped /n/ (and /o/), leaving the /n/ segment to leak
into the stored proposal's header.

## Root cause

git diff --no-index /dev/null n/<path> emits both /n/<path> and
/n/<path>; ewrite_diff_header covered only /n/ and /o/.

## Fix

ewrite_diff_header now normalizes all four temporary-prefix
combinations (/o/, /o/, /n/, /n/ -> /, /, /,
/) and replaces backslashes with forward slashes **before** the
prefix rewrites so Windows temp paths are also covered (previously the
backslash replacement ran last, after the forward-slash prefix checks).

## Scope (per the focused-PR boundary)

- one source file (src/workflow/mod.rs);
- one regression test (create_file_renders_without_leaked_temp_prefix);
- no parser changes;
- no provider changes;
- no pilot-metric or documentation changes.

## Verification

- cargo fmt --check clean
- cargo clippy --all-targets --all-features -- -D warnings clean
- cargo test --lib workflow::render_diagnostics_tests — 7 passed, 0 failed
  (includes the new focused regression test)